### PR TITLE
improve error message if TLS connection fails

### DIFF
--- a/crypto/tls/src/main/java/org/openecard/crypto/tls/verify/KeyLengthVerifier.java
+++ b/crypto/tls/src/main/java/org/openecard/crypto/tls/verify/KeyLengthVerifier.java
@@ -70,8 +70,8 @@ public class KeyLengthVerifier implements CertificateVerifier {
 	    }
 	} catch (CertificateException | IOException ex) {
 	    String msg = "Failed to convert certificates to JCA format.";
-	    logger.error(msg);
-	    throw new CertificateVerificationException(msg);
+	    logger.error(msg, ex);
+	    throw new CertificateVerificationException(msg, ex);
 	}
     }
 

--- a/crypto/tls/src/main/java/org/openecard/crypto/tls/verify/KeyLengthVerifier.java
+++ b/crypto/tls/src/main/java/org/openecard/crypto/tls/verify/KeyLengthVerifier.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.security.PublicKey;
 import java.security.cert.CertPath;
 import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
 import java.security.interfaces.DSAPublicKey;
 import java.security.interfaces.ECPublicKey;
 import java.security.interfaces.RSAPublicKey;
@@ -66,7 +67,7 @@ public class KeyLengthVerifier implements CertificateVerifier {
 		    throw new CertificateVerificationException(msg);
 		}
 
-		assertKeyLength(reference, KeyTools.getKeySize(pk));
+		assertKeyLength(reference, KeyTools.getKeySize(pk), c);
 	    }
 	} catch (CertificateException | IOException ex) {
 	    String msg = "Failed to convert certificates to JCA format.";
@@ -75,9 +76,14 @@ public class KeyLengthVerifier implements CertificateVerifier {
 	}
     }
 
-    private void assertKeyLength(int reference, int numbits) throws CertificateVerificationException {
+    private void assertKeyLength(int reference, int numbits, java.security.cert.Certificate cert) throws CertificateVerificationException {
 	if (numbits < reference) {
 	    String msg = "The key size in the certificate does not meet the requirements ";
+	    if (cert instanceof X509Certificate) {
+	        msg = "The key size in the certificate \"" +
+	              ((X509Certificate)cert).getSubjectX500Principal() +
+	              "\" does not meet the requirements ";
+	    }
 	    msg += String.format("(%d < %d).", numbits, reference);
 	    throw new CertificateVerificationException(msg);
 	}


### PR DESCRIPTION
The exception is just caught and not printed anywhere. This prints the
exception and the stack trace, in addition is is given as a caused by
to the new exception, so it does not get lost.

Signed-off-by: Hauke Mehrtens hauke@hauke-m.de
