### PR TITLE
Fixed HostnameVerifier class for certificates containing upper-case characters.

### DIFF
--- a/crypto/tls/src/main/java/org/openecard/crypto/tls/verify/HostnameVerifier.java
+++ b/crypto/tls/src/main/java/org/openecard/crypto/tls/verify/HostnameVerifier.java
@@ -22,6 +22,8 @@
 
 package org.openecard.crypto.tls.verify;
 
+import java.util.Locale;
+
 import org.openecard.bouncycastle.asn1.ASN1Encodable;
 import org.openecard.bouncycastle.asn1.x500.RDN;
 import org.openecard.bouncycastle.asn1.x500.style.BCStrictStyle;
@@ -44,90 +46,90 @@ import org.slf4j.LoggerFactory;
  */
 public class HostnameVerifier implements CertificateVerifier {
 
-    private static final Logger logger = LoggerFactory.getLogger(HostnameVerifier.class);
+	private static final Logger logger = LoggerFactory.getLogger(HostnameVerifier.class);
 
-    @Override
-    public void isValid(Certificate chain, String hostOrIp) throws CertificateVerificationException {
-	org.openecard.bouncycastle.asn1.x509.Certificate cert = chain.getCertificateAt(0);
-	boolean success = false;
-	boolean isIPAddr = IPAddress.isValid(hostOrIp);
+	@Override
+	public void isValid(Certificate chain, String hostOrIp) throws CertificateVerificationException {
+		org.openecard.bouncycastle.asn1.x509.Certificate cert = chain.getCertificateAt(0);
+		boolean success = false;
+		boolean isIPAddr = IPAddress.isValid(hostOrIp);
 
-	// check hostname against Subject CN
-	if (! isIPAddr) {
-	    RDN[] cn = cert.getSubject().getRDNs(BCStrictStyle.CN);
-	    if (cn.length == 0) {
-		throw new CertificateVerificationException("No CN entry in certificate's Subject.");
-	    }
-	    // CN is always a string type
-	    String hostNameReference = cn[0].getFirst().getValue().toString();
-	    success = checkWildcardName(hostOrIp, hostNameReference);
-	} else {
-	    logger.debug("Given name is an IP Address. Validation relies solely on the SubjectAlternativeName.");
-	}
-	// stop execution when we found a valid name
-	if (success) {
-	    return;
-	}
-
-	// evaluate subject alternative name
-	Extensions ext = cert.getTBSCertificate().getExtensions();
-	Extension subjAltExt = ext.getExtension(Extension.subjectAlternativeName);
-	if (subjAltExt != null) {
-	    // extract SubjAltName from Extensions
-	    GeneralNames gns = GeneralNames.fromExtensions(ext, Extension.subjectAlternativeName);
-	    GeneralName[] names = gns.getNames();
-	    for (GeneralName name : names) {
-		ASN1Encodable reference = name.getName();
-		switch (name.getTagNo()) {
-		    case GeneralName.dNSName:
-			if (! isIPAddr) {
-			    success = checkWildcardName(hostOrIp, reference.toString());
+		// check hostname against Subject CN
+		if (! isIPAddr) {
+			RDN[] cn = cert.getSubject().getRDNs(BCStrictStyle.CN);
+			if (cn.length == 0) {
+				throw new CertificateVerificationException("No CN entry in certificate's Subject.");
 			}
-			break;
-		    case GeneralName.iPAddress:
-			if (isIPAddr) {
-			    // TODO: validate IP Addresses
-			    logger.warn("IP Address verification not supported.");
-			}
-			break;
-		    default:
-			logger.debug("Unsupported GeneralName ({}) tag in SubjectAlternativeName.", name.getTagNo());
+			// CN is always a string type
+			String hostNameReference = cn[0].getFirst().getValue().toString();
+			success = checkWildcardName(hostOrIp, hostNameReference);
+		} else {
+			logger.debug("Given name is an IP Address. Validation relies solely on the SubjectAlternativeName.");
 		}
 		// stop execution when we found a valid name
 		if (success) {
-		    return;
+			return;
 		}
-	    }
+
+		// evaluate subject alternative name
+		Extensions ext = cert.getTBSCertificate().getExtensions();
+		Extension subjAltExt = ext.getExtension(Extension.subjectAlternativeName);
+		if (subjAltExt != null) {
+			// extract SubjAltName from Extensions
+			GeneralNames gns = GeneralNames.fromExtensions(ext, Extension.subjectAlternativeName);
+			GeneralName[] names = gns.getNames();
+			for (GeneralName name : names) {
+				ASN1Encodable reference = name.getName();
+				switch (name.getTagNo()) {
+				case GeneralName.dNSName:
+					if (! isIPAddr) {
+						success = checkWildcardName(hostOrIp, reference.toString());
+					}
+					break;
+				case GeneralName.iPAddress:
+					if (isIPAddr) {
+						// TODO: validate IP Addresses
+						logger.warn("IP Address verification not supported.");
+					}
+					break;
+				default:
+					logger.debug("Unsupported GeneralName ({}) tag in SubjectAlternativeName.", name.getTagNo());
+				}
+				// stop execution when we found a valid name
+				if (success) {
+					return;
+				}
+			}
+		}
+
+		// evaluate result
+		if (! success) {
+			String errorMsg = "Hostname in certificate differs from actually requested host.";
+			throw new CertificateVerificationException(errorMsg);
+		}
 	}
 
-	// evaluate result
-	if (! success) {
-	    String errorMsg = "Hostname in certificate differs from actually requested host.";
-	    throw new CertificateVerificationException(errorMsg);
+	private static boolean checkWildcardName(String givenHost, String wildcardHost)
+			throws CertificateVerificationException {
+		logger.debug("Comparing connection hostname against certificate hostname: [{}] [{}]", givenHost, wildcardHost);
+		String[] givenToken = givenHost.toLowerCase(Locale.ENGLISH).split("\\.");
+		String[] wildToken = wildcardHost.toLowerCase(Locale.ENGLISH).split("\\.");
+		// error if number of token is different
+		if (givenToken.length != wildToken.length) {
+			return false;
+		}
+		// compare entries
+		for (int i = 0; i < givenToken.length; i++) {
+			if (wildToken[i].equals("*")) {
+				// skip wildcard part
+				continue;
+			}
+			if (! givenToken[i].equals(wildToken[i])) {
+				return false;
+			}
+		}
+		// each part processed and no error -> success
+		return true;
 	}
-    }
-
-    private static boolean checkWildcardName(String givenHost, String wildcardHost)
-	    throws CertificateVerificationException {
-	logger.debug("Comparing connection hostname against certificate hostname: [{}] [{}]", givenHost, wildcardHost);
-	String[] givenToken = givenHost.split("\\.");
-	String[] wildToken = wildcardHost.split("\\.");
-	// error if number of token is different
-	if (givenToken.length != wildToken.length) {
-	    return false;
-	}
-	// compare entries
-	for (int i = 0; i < givenToken.length; i++) {
-	    if (wildToken[i].equals("*")) {
-		// skip wildcard part
-		continue;
-	    }
-	    if (! givenToken[i].equals(wildToken[i])) {
-		return false;
-	    }
-	}
-	// each part processed and no error -> success
-	return true;
-    }
 
 }


### PR DESCRIPTION
Fixed HostnameVerifier for certificates containing upper-case characters in the CN. Currently, the string comparison is case-sensitive, which means that the connection will fail due to non-matching host name, if the certificate contains upper-case characters, but the actual connection URL is lower-case (default).

However, host name comparison should always be case-insensitive, as per RFC 4343 and 6125. So, to solve the problem, we convert both strings to lower-case before the actual string comparison. Also, we force ENGLISH locale to avoid some Unicode issues. This should make the behavior of *Open eCard App* more consistent with *Ausweis App 2*. The latter _does_ accept upper-case characters in CN just fine.


    3.  Name Lookup, Label Types, and CLASS
    
    According to the original DNS design decision, comparisons on name
    lookup for DNS queries should be case insensitive [STD13].  That is
    to say, a lookup string octet with a value in the inclusive range
    from 0x41 to 0x5A, the uppercase ASCII letters, MUST match the
    identical value and also match the corresponding value in the
    inclusive range from 0x61 to 0x7A, the lowercase ASCII letters.  A
    lookup string octet with a lowercase ASCII letter value MUST
    similarly match the identical value and also match the corresponding
    value in the uppercase ASCII letter range.

https://www.ietf.org/rfc/rfc4343.txt

    6.4.1.  Checking of Traditional Domain Names
    
    If the DNS domain name portion of a reference identifier is a
    "traditional domain name", then matching of the reference identifier
    against the presented identifier is performed by comparing the set of
    domain name labels using a case-insensitive ASCII comparison, as
    clarified by [DNS-CASE] (e.g., "WWW.Example.Com" would be lower-cased
    to "www.example.com" for comparison purposes).  Each label MUST match
    in order for the names to be considered to match, except as
    supplemented by the rule about checking of wildcard labels
    (Section 6.4.3).

https://tools.ietf.org/html/rfc6125