### PR TITLE
Introduce explicit UserConsentNavigator factories with explicit dependencies

### DIFF
--- a/clients/android-lib/src/main/java/org/openecard/android/lib/ServiceContext.java
+++ b/clients/android-lib/src/main/java/org/openecard/android/lib/ServiceContext.java
@@ -227,11 +227,14 @@ public class ServiceContext extends Application implements EventCallback, Servic
 	    @Override
 	    public void run() {
 		Runnable runner = getEacStarter();
-		if(runner != null) {
+		if(runner == null) {
+		    LOG.error("The Eac GUI starter was not initialized as required!");
+		}
+		else {
 		    runner.run();
 		}
 	    }
-	}
+	};
 	factories.add(new EacNavigatorFactory(delegatingRunnable));
 	factories.add(new InsertCardNavigatorFactory());
 	gui = new AndroidUserConsent(this, factories);

--- a/clients/android-lib/src/main/java/org/openecard/android/lib/ServiceContext.java
+++ b/clients/android-lib/src/main/java/org/openecard/android/lib/ServiceContext.java
@@ -213,8 +213,7 @@ public class ServiceContext extends Application implements EventCallback, Servic
 	}
 
 	// initialize gui
-	
-	ArrayList<UserConsentNavigatorFactory> factories = new ArrayList<UserConsentNavigatorFactory>();
+	ArrayList<UserConsentNavigatorFactory> factories = new ArrayList<>();
 	factories.add(new EacNavigatorFactory());
 	factories.add(new InsertCardNavigatorFactory());
 	gui = new AndroidUserConsent(this, factories);

--- a/clients/android-lib/src/main/java/org/openecard/android/lib/ServiceContext.java
+++ b/clients/android-lib/src/main/java/org/openecard/android/lib/ServiceContext.java
@@ -93,7 +93,8 @@ public class ServiceContext extends Application implements EventCallback, Servic
     private Dispatcher dispatcher;
     private TerminalFactory terminalFactory;
     private TinyManagement management;
-
+    private Runnable guiStarter;
+    
     private UserConsent gui;
 
     // true if already initialized
@@ -200,6 +201,14 @@ public class ServiceContext extends Application implements EventCallback, Servic
 	return manager;
     }
 
+    public Runnable getEacStarter() {
+	return guiStarter;
+    }
+    
+    public void setEacStarter(Runnable guiStarter) {
+	this.guiStarter = guiStarter;
+    }
+
 
     ///
     /// Initialization & Shutdown
@@ -214,7 +223,16 @@ public class ServiceContext extends Application implements EventCallback, Servic
 
 	// initialize gui
 	ArrayList<UserConsentNavigatorFactory> factories = new ArrayList<>();
-	factories.add(new EacNavigatorFactory());
+	Runnable delegatingRunnable = new Runnable() {
+	    @Override
+	    public void run() {
+		Runnable runner = getEacStarter();
+		if(runner != null) {
+		    runner.run();
+		}
+	    }
+	}
+	factories.add(new EacNavigatorFactory(delegatingRunnable));
 	factories.add(new InsertCardNavigatorFactory());
 	gui = new AndroidUserConsent(this, factories);
 

--- a/clients/android-lib/src/main/java/org/openecard/android/lib/ServiceContext.java
+++ b/clients/android-lib/src/main/java/org/openecard/android/lib/ServiceContext.java
@@ -64,6 +64,10 @@ import iso.std.iso_iec._24727.tech.schema.EstablishContextResponse;
 import iso.std.iso_iec._24727.tech.schema.Initialize;
 import iso.std.iso_iec._24727.tech.schema.ReleaseContext;
 import iso.std.iso_iec._24727.tech.schema.Terminate;
+import java.util.ArrayList;
+import org.openecard.gui.android.EacNavigatorFactory;
+import org.openecard.gui.android.InsertCardNavigatorFactory;
+import org.openecard.gui.android.UserConsentNavigatorFactory;
 
 
 /**
@@ -209,7 +213,11 @@ public class ServiceContext extends Application implements EventCallback, Servic
 	}
 
 	// initialize gui
-	gui = new AndroidUserConsent(this);
+	
+	ArrayList<UserConsentNavigatorFactory> factories = new ArrayList<UserConsentNavigatorFactory>();
+	factories.add(new EacNavigatorFactory());
+	factories.add(new InsertCardNavigatorFactory());
+	gui = new AndroidUserConsent(this, factories);
 
 	// set up nfc and android marshaller
 	IFDProperties.setProperty(IFD_FACTORY_KEY, IFD_FACTORY_VALUE);

--- a/gui/android/src/main/java/org/openecard/gui/android/AndroidUserConsent.java
+++ b/gui/android/src/main/java/org/openecard/gui/android/AndroidUserConsent.java
@@ -24,6 +24,7 @@ package org.openecard.gui.android;
 
 import org.openecard.gui.android.eac.EacNavigator;
 import android.content.Context;
+import java.util.List;
 import org.openecard.gui.FileDialog;
 import org.openecard.gui.MessageDialog;
 import org.openecard.gui.UserConsent;
@@ -39,21 +40,23 @@ import org.openecard.gui.definition.UserConsentDescription;
 public class AndroidUserConsent implements UserConsent {
 
     private final Context androidCtx;
+    private final List<UserConsentNavigatorFactory> factories;
 
-    public AndroidUserConsent(Context androidCtx) {
+    public AndroidUserConsent(Context androidCtx, List<UserConsentNavigatorFactory> factories) {
 	this.androidCtx = androidCtx;
+	this.factories = factories;
     }
 
     @Override
     public UserConsentNavigator obtainNavigator(UserConsentDescription uc) {
-	String dialogType = uc.getDialogType();
-	if ("EAC".equals(dialogType)) {
-	    return EacNavigator.createFrom(androidCtx, uc);
-	} else if ("insert_card_dialog".equals(dialogType)) {
-	    return new InsertCardNavigator(uc);
-	} else {
-	    throw new UnsupportedOperationException("Not supported yet.");
+	
+	for (UserConsentNavigatorFactory factory : factories) {
+	    if(factory.canCreateFrom(uc, androidCtx))
+	    {
+		return factory.createFrom(uc, androidCtx);
+	    }
 	}
+	throw new UnsupportedOperationException("Not supported yet.");
     }
 
     @Override

--- a/gui/android/src/main/java/org/openecard/gui/android/AndroidUserConsent.java
+++ b/gui/android/src/main/java/org/openecard/gui/android/AndroidUserConsent.java
@@ -48,7 +48,7 @@ public class AndroidUserConsent implements UserConsent {
     public UserConsentNavigator obtainNavigator(UserConsentDescription uc) {
 	String dialogType = uc.getDialogType();
 	if ("EAC".equals(dialogType)) {
-	    return new EacNavigator(androidCtx, uc);
+	    return EacNavigator.createFrom(androidCtx, uc);
 	} else if ("insert_card_dialog".equals(dialogType)) {
 	    return new InsertCardNavigator(uc);
 	} else {

--- a/gui/android/src/main/java/org/openecard/gui/android/EacNavigatorFactory.java
+++ b/gui/android/src/main/java/org/openecard/gui/android/EacNavigatorFactory.java
@@ -23,8 +23,12 @@
 package org.openecard.gui.android;
 
 import android.content.Context;
+import java.util.ArrayList;
 import org.openecard.gui.UserConsentNavigator;
+import org.openecard.gui.android.eac.EacGuiImpl;
+import org.openecard.gui.android.eac.EacGuiService;
 import org.openecard.gui.android.eac.EacNavigator;
+import org.openecard.gui.definition.Step;
 import org.openecard.gui.definition.UserConsentDescription;
 
 /**
@@ -43,7 +47,15 @@ public class EacNavigatorFactory implements UserConsentNavigatorFactory{
 	if (!this.canCreateFrom(uc, androidCtx)) {
 	    throw new IllegalArgumentException("This factory explicitly does not support the given user consent description.");
 	}
-	return EacNavigator.createFrom(androidCtx, uc);
+	
+	ArrayList<Step> steps = new ArrayList<>(uc.getSteps());
+	EacGuiImpl guiService;
+	
+	guiService = new EacGuiImpl();
+	EacGuiService.setGuiImpl(guiService);
+	
+	return new EacNavigator(guiService, steps);
+    
     }
     
 }

--- a/gui/android/src/main/java/org/openecard/gui/android/EacNavigatorFactory.java
+++ b/gui/android/src/main/java/org/openecard/gui/android/EacNavigatorFactory.java
@@ -37,6 +37,12 @@ import org.openecard.gui.definition.UserConsentDescription;
  */
 public class EacNavigatorFactory implements UserConsentNavigatorFactory{
 
+    private final Runnable eacGuiStarter;
+
+    public EacNavigatorFactory(Runnable eacGuiStarter) {
+	this.eacGuiStarter = eacGuiStarter;
+    }
+    
     @Override
     public boolean canCreateFrom(UserConsentDescription uc, Context androidCtx) {
 	return "EAC".equals(uc.getDialogType());
@@ -53,6 +59,7 @@ public class EacNavigatorFactory implements UserConsentNavigatorFactory{
 	
 	guiService = new EacGuiImpl();
 	EacGuiService.setGuiImpl(guiService);
+	eacGuiStarter.run();
 	
 	return new EacNavigator(guiService, steps);
     

--- a/gui/android/src/main/java/org/openecard/gui/android/EacNavigatorFactory.java
+++ b/gui/android/src/main/java/org/openecard/gui/android/EacNavigatorFactory.java
@@ -1,0 +1,49 @@
+/****************************************************************************
+ * Copyright (C) 2017 ecsec GmbH.
+ * All rights reserved.
+ * Contact: ecsec GmbH (info@ecsec.de)
+ *
+ * This file is part of the Open eCard App.
+ *
+ * GNU General Public License Usage
+ * This file may be used under the terms of the GNU General Public
+ * License version 3.0 as published by the Free Software Foundation
+ * and appearing in the file LICENSE.GPL included in the packaging of
+ * this file. Please review the following information to ensure the
+ * GNU General Public License version 3.0 requirements will be met:
+ * http://www.gnu.org/copyleft/gpl.html.
+ *
+ * Other Usage
+ * Alternatively, this file may be used in accordance with the terms
+ * and conditions contained in a signed written agreement between
+ * you and ecsec GmbH.
+ *
+ ***************************************************************************/
+
+package org.openecard.gui.android;
+
+import android.content.Context;
+import org.openecard.gui.UserConsentNavigator;
+import org.openecard.gui.android.eac.EacNavigator;
+import org.openecard.gui.definition.UserConsentDescription;
+
+/**
+ *
+ * @author Neil Crossley
+ */
+public class EacNavigatorFactory implements UserConsentNavigatorFactory{
+
+    @Override
+    public boolean canCreateFrom(UserConsentDescription uc, Context androidCtx) {
+	return "EAC".equals(uc.getDialogType());
+    }
+
+    @Override
+    public UserConsentNavigator createFrom(UserConsentDescription uc, Context androidCtx) {
+	if (!this.canCreateFrom(uc, androidCtx)) {
+	    throw new IllegalArgumentException("This factory explicitly does not support the given user consent description.");
+	}
+	return EacNavigator.createFrom(androidCtx, uc);
+    }
+    
+}

--- a/gui/android/src/main/java/org/openecard/gui/android/InsertCardNavigatorFactory.java
+++ b/gui/android/src/main/java/org/openecard/gui/android/InsertCardNavigatorFactory.java
@@ -1,0 +1,48 @@
+/****************************************************************************
+ * Copyright (C) 2017 ecsec GmbH.
+ * All rights reserved.
+ * Contact: ecsec GmbH (info@ecsec.de)
+ *
+ * This file is part of the Open eCard App.
+ *
+ * GNU General Public License Usage
+ * This file may be used under the terms of the GNU General Public
+ * License version 3.0 as published by the Free Software Foundation
+ * and appearing in the file LICENSE.GPL included in the packaging of
+ * this file. Please review the following information to ensure the
+ * GNU General Public License version 3.0 requirements will be met:
+ * http://www.gnu.org/copyleft/gpl.html.
+ *
+ * Other Usage
+ * Alternatively, this file may be used in accordance with the terms
+ * and conditions contained in a signed written agreement between
+ * you and ecsec GmbH.
+ *
+ ***************************************************************************/
+
+package org.openecard.gui.android;
+
+import android.content.Context;
+import org.openecard.gui.UserConsentNavigator;
+import org.openecard.gui.definition.UserConsentDescription;
+
+/**
+ *
+ * @author Neil Crossley
+ */
+public class InsertCardNavigatorFactory implements UserConsentNavigatorFactory {
+
+    @Override
+    public boolean canCreateFrom(UserConsentDescription uc, Context androidCtx) {
+	return "insert_card_dialog".equals(uc.getDialogType());
+    }
+
+    @Override
+    public UserConsentNavigator createFrom(UserConsentDescription uc, Context androidCtx) {
+	if (!this.canCreateFrom(uc, androidCtx)) {
+	    throw new IllegalArgumentException("This factory explicitly does not support the given user consent description.");
+	}
+	return new InsertCardNavigator(uc);
+    }
+    
+}

--- a/gui/android/src/main/java/org/openecard/gui/android/UserConsentNavigatorFactory.java
+++ b/gui/android/src/main/java/org/openecard/gui/android/UserConsentNavigatorFactory.java
@@ -1,0 +1,38 @@
+/****************************************************************************
+ * Copyright (C) 2017 ecsec GmbH.
+ * All rights reserved.
+ * Contact: ecsec GmbH (info@ecsec.de)
+ *
+ * This file is part of the Open eCard App.
+ *
+ * GNU General Public License Usage
+ * This file may be used under the terms of the GNU General Public
+ * License version 3.0 as published by the Free Software Foundation
+ * and appearing in the file LICENSE.GPL included in the packaging of
+ * this file. Please review the following information to ensure the
+ * GNU General Public License version 3.0 requirements will be met:
+ * http://www.gnu.org/copyleft/gpl.html.
+ *
+ * Other Usage
+ * Alternatively, this file may be used in accordance with the terms
+ * and conditions contained in a signed written agreement between
+ * you and ecsec GmbH.
+ *
+ ***************************************************************************/
+
+package org.openecard.gui.android;
+
+import android.content.Context;
+import org.openecard.gui.UserConsentNavigator;
+import org.openecard.gui.definition.UserConsentDescription;
+
+/**
+ *
+ * @author Neil Crossley
+ */
+public interface UserConsentNavigatorFactory {
+    
+    boolean canCreateFrom(UserConsentDescription uc, Context androidCtx);
+    
+    UserConsentNavigator createFrom(UserConsentDescription uc, Context androidCtx);
+}

--- a/gui/android/src/main/java/org/openecard/gui/android/eac/EacGuiService.java
+++ b/gui/android/src/main/java/org/openecard/gui/android/eac/EacGuiService.java
@@ -45,10 +45,6 @@ public class EacGuiService extends Service {
 	serviceImpl.deliver(impl);
     }
 
-    static synchronized Promise<EacGuiImpl> getServiceImpl() {
-	return serviceImpl;
-    }
-
     @Override
     public synchronized int onStartCommand(Intent intent, int flags, int startId) {
 	prepare();

--- a/gui/android/src/main/java/org/openecard/gui/android/eac/EacNavigator.java
+++ b/gui/android/src/main/java/org/openecard/gui/android/eac/EacNavigator.java
@@ -43,32 +43,33 @@ import org.openecard.gui.definition.UserConsentDescription;
  */
 public class EacNavigator implements UserConsentNavigator {
 
-    private final Context androidCtx;
-
-    private final UserConsentDescription ucd;
-    private final ArrayList<Step> steps;
+    private final List<Step> steps;
 
     private EacGuiImpl guiService = null;
     private int idx = -1;
     private boolean pinFirstUse = true;
 
 
-    public EacNavigator(Context androidCtx, UserConsentDescription ucd) throws UnsupportedOperationException {
-	this.androidCtx = androidCtx;
-	this.ucd = ucd;
-	this.steps = new ArrayList<>(ucd.getSteps());
-
+    public EacNavigator(EacGuiImpl guiService, List<Step> steps) {
+	this.guiService = guiService;
+	this.steps = steps;
+    }
+    
+    public static EacNavigator createFrom(Context androidCtx, UserConsentDescription ucd) throws UnsupportedOperationException {
+	ArrayList<Step> steps = new ArrayList<>(ucd.getSteps());
+	EacGuiImpl guiService;
+	
 	String dialogType = ucd.getDialogType();
 	if ("EAC".equals(dialogType)) {
 	    // get GUI service
-	    this.guiService = new EacGuiImpl();
-	    EacGuiService.setGuiImpl(this.guiService);
+	    guiService = new EacGuiImpl();
+	    EacGuiService.setGuiImpl(guiService);
 	} else {
 	    throw new UnsupportedOperationException("Unsupported Dialog type requested.");
 	}
+	return new EacNavigator(guiService, steps);
     }
-
-
+    
     @Override
     public boolean hasNext() {
 	return idx < (steps.size() - 1);

--- a/gui/android/src/main/java/org/openecard/gui/android/eac/EacNavigator.java
+++ b/gui/android/src/main/java/org/openecard/gui/android/eac/EacNavigator.java
@@ -55,21 +55,6 @@ public class EacNavigator implements UserConsentNavigator {
 	this.steps = steps;
     }
     
-    public static EacNavigator createFrom(Context androidCtx, UserConsentDescription ucd) throws UnsupportedOperationException {
-	ArrayList<Step> steps = new ArrayList<>(ucd.getSteps());
-	EacGuiImpl guiService;
-	
-	String dialogType = ucd.getDialogType();
-	if ("EAC".equals(dialogType)) {
-	    // get GUI service
-	    guiService = new EacGuiImpl();
-	    EacGuiService.setGuiImpl(guiService);
-	} else {
-	    throw new UnsupportedOperationException("Unsupported Dialog type requested.");
-	}
-	return new EacNavigator(guiService, steps);
-    }
-    
     @Override
     public boolean hasNext() {
 	return idx < (steps.size() - 1);

--- a/gui/android/src/test/java/org/openecard/gui/android/EacNavigatorFactoryTest.java
+++ b/gui/android/src/test/java/org/openecard/gui/android/EacNavigatorFactoryTest.java
@@ -31,8 +31,10 @@ import org.openecard.gui.UserConsentNavigator;
 import org.openecard.gui.android.eac.EacGui;
 import org.openecard.gui.android.eac.EacGuiImpl;
 import org.openecard.gui.android.eac.EacGuiService;
+import org.openecard.gui.android.eac.EacNavigator;
 import org.openecard.gui.definition.Step;
 import org.openecard.gui.definition.UserConsentDescription;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import org.testng.annotations.Test;
@@ -49,6 +51,23 @@ public class EacNavigatorFactoryTest {
     UserConsentDescription ucd;
     @Mocked
     EacGui.Stub stub;
+    @Mocked
+    Runnable guiStarter;
+    
+    @Test
+    public void testGivenCorrectValuesThenCreateFromShouldCreateCorrectInstance() {
+	final List<Step> expectedSteps = createInitialSteps();
+	new Expectations() {{
+	    ucd.getDialogType(); result = "EAC";
+	    ucd.getSteps(); result = expectedSteps;
+	}};
+	EacGuiService.prepare();
+	
+	EacNavigatorFactory sut = new EacNavigatorFactory(guiStarter);
+	final UserConsentNavigator result = sut.createFrom(ucd, androidCtx);
+	
+	assertEquals(result.getClass(), EacNavigator.class);
+    }
     
     @Test
     public void testGivenCorrectValuesThenCreateFromShouldBeCorrect() {
@@ -59,7 +78,7 @@ public class EacNavigatorFactoryTest {
 	}};
 	EacGuiService.prepare();
 	
-	EacNavigatorFactory sut = new EacNavigatorFactory();
+	EacNavigatorFactory sut = new EacNavigatorFactory(guiStarter);
 	final UserConsentNavigator result = sut.createFrom(ucd, androidCtx);
 	
 	assertNotNull(result);
@@ -83,7 +102,23 @@ public class EacNavigatorFactoryTest {
 	
 	EacGuiService.prepare();
 	
-	EacNavigatorFactory sut = new EacNavigatorFactory();
+	EacNavigatorFactory sut = new EacNavigatorFactory(guiStarter);
+	final UserConsentNavigator result = sut.createFrom(ucd, androidCtx);
+	
+    }
+    
+    @Test
+    public void testGivenCorrectValuesThenCreateFromShouldRunEacRunnable() {
+	final List<Step> expectedSteps = createInitialSteps();
+	EacGuiService.prepare();
+
+	new Expectations() {{
+	    ucd.getDialogType(); result = "EAC";
+	    ucd.getSteps(); result = expectedSteps;
+	    guiStarter.run();
+	}};
+	
+	EacNavigatorFactory sut = new EacNavigatorFactory(guiStarter);
 	final UserConsentNavigator result = sut.createFrom(ucd, androidCtx);
 	
     }

--- a/gui/android/src/test/java/org/openecard/gui/android/EacNavigatorFactoryTest.java
+++ b/gui/android/src/test/java/org/openecard/gui/android/EacNavigatorFactoryTest.java
@@ -1,0 +1,95 @@
+/****************************************************************************
+ * Copyright (C) 2017 ecsec GmbH.
+ * All rights reserved.
+ * Contact: ecsec GmbH (info@ecsec.de)
+ *
+ * This file is part of the Open eCard App.
+ *
+ * GNU General Public License Usage
+ * This file may be used under the terms of the GNU General Public
+ * License version 3.0 as published by the Free Software Foundation
+ * and appearing in the file LICENSE.GPL included in the packaging of
+ * this file. Please review the following information to ensure the
+ * GNU General Public License version 3.0 requirements will be met:
+ * http://www.gnu.org/copyleft/gpl.html.
+ *
+ * Other Usage
+ * Alternatively, this file may be used in accordance with the terms
+ * and conditions contained in a signed written agreement between
+ * you and ecsec GmbH.
+ *
+ ***************************************************************************/
+
+package org.openecard.gui.android;
+
+import android.content.Context;
+import java.util.Arrays;
+import java.util.List;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.openecard.gui.UserConsentNavigator;
+import org.openecard.gui.android.eac.EacGui;
+import org.openecard.gui.android.eac.EacGuiImpl;
+import org.openecard.gui.android.eac.EacGuiService;
+import org.openecard.gui.definition.Step;
+import org.openecard.gui.definition.UserConsentDescription;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import org.testng.annotations.Test;
+
+/**
+ *
+ * @author Neil Crossley
+ */
+public class EacNavigatorFactoryTest {
+    
+    @Mocked
+    Context androidCtx;
+    @Mocked
+    UserConsentDescription ucd;
+    @Mocked
+    EacGui.Stub stub;
+    
+    @Test
+    public void testGivenCorrectValuesThenCreateFromShouldBeCorrect() {
+	final List<Step> expectedSteps = createInitialSteps();
+	new Expectations() {{
+	    ucd.getDialogType(); result = "EAC";
+	    ucd.getSteps(); result = expectedSteps;
+	}};
+	EacGuiService.prepare();
+	
+	EacNavigatorFactory sut = new EacNavigatorFactory();
+	final UserConsentNavigator result = sut.createFrom(ucd, androidCtx);
+	
+	assertNotNull(result);
+	assertTrue(result.hasNext());
+    }
+    
+    @Test
+    public void testGivenCorrectValuesThenCreateFromShouldStoreNewGui() {
+	final List<Step> expectedSteps = createInitialSteps();
+	EacGuiService.prepare();
+
+	new Expectations() {{
+	    ucd.getDialogType(); result = "EAC";
+	    ucd.getSteps(); result = expectedSteps;
+	    
+	    EacGuiService singleton;
+	    {
+		EacGuiService.setGuiImpl((EacGuiImpl)any);
+	    }
+	}};
+	
+	EacGuiService.prepare();
+	
+	EacNavigatorFactory sut = new EacNavigatorFactory();
+	final UserConsentNavigator result = sut.createFrom(ucd, androidCtx);
+	
+    }
+
+    private List<Step> createInitialSteps() {
+	return Arrays.asList(new Step("Some text"), new Step("Some text"), new Step("Some text"), new Step("Some text"));
+    }
+    
+}

--- a/gui/android/src/test/java/org/openecard/gui/android/eac/EacGuiImplTest.java
+++ b/gui/android/src/test/java/org/openecard/gui/android/eac/EacGuiImplTest.java
@@ -63,40 +63,6 @@ public class EacGuiImplTest {
     EacGui.Stub stub;
 
     @Test
-    public void testGivenCorrectValuesThenCreateFromShouldBeCorrect() {
-	final List<Step> expectedSteps = createInitialSteps();
-	new Expectations() {{
-	    ucd.getDialogType(); result = "EAC";
-	    ucd.getSteps(); result = expectedSteps;
-	}};
-	EacGuiService.prepare();
-	
-	final EacNavigator result = EacNavigator.createFrom(androidCtx, ucd);
-	
-	assertNotNull(result);
-	assertTrue(result.hasNext());
-    }
-    
-    @Test
-    public void testGivenCorrectValuesThenCreateFromShouldStoreNewGui() {
-	final List<Step> expectedSteps = createInitialSteps();
-	EacGuiService.prepare();
-
-	new Expectations() {{
-	    ucd.getDialogType(); result = "EAC";
-	    ucd.getSteps(); result = expectedSteps;
-	    
-	    EacGuiService singleton;
-	    {
-		EacGuiService.setGuiImpl((EacGuiImpl)any);
-	    }
-	}};
-	
-	EacGuiService.prepare();
-	EacNavigator.createFrom(androidCtx, ucd);
-    }
-    
-    @Test
     public void testPinOkFirstTime() throws InterruptedException, RemoteException {
 	EacGuiService.prepare();
 	


### PR DESCRIPTION
I've addressed some issues with the creation of the specific instances of the subclasses of UserConsentNavigator. Many decision-relevant information is available after the initialization of the ServiceContext, making the dependencies of these subclasses optional. I've tried to make them more explicitly visible in the code.

tldr; the following occurs in EacNavigatorFactory:

- create the instance of `EacGuiImpl`
- assigning the instance of `EacGuiImpl` to the `EacGuiService`
- starting the connection to to `EacGuiService`
- creating `EacNavigator`

Additionally, tests 😃