### PR TITLE
Take back allowing sha1

### DIFF
--- a/addon/pom.xml
+++ b/addon/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-sha1</version>
+		<version>1.4.1-SNAPSHOT</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/addon/pom.xml
+++ b/addon/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-rc.5-SNAPSHOT</version>
+		<version>1.4.0-rc.5+sha1</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/addon/pom.xml
+++ b/addon/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-rc.5+sha1</version>
+		<version>1.4.0-rc.6-SNAPSHOT</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/addon/pom.xml
+++ b/addon/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-rc.6-SNAPSHOT</version>
+		<version>1.4.0-sha1</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/addons/chipgateway/pom.xml
+++ b/addons/chipgateway/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>addons</artifactId>
-		<version>1.4.0-rc.5-SNAPSHOT</version>
+		<version>1.4.0-rc.5+sha1</version>
 	</parent>
 
 	<groupId>org.openecard.addons</groupId>

--- a/addons/chipgateway/pom.xml
+++ b/addons/chipgateway/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>addons</artifactId>
-		<version>1.4.0-rc.6-SNAPSHOT</version>
+		<version>1.4.0-sha1</version>
 	</parent>
 
 	<groupId>org.openecard.addons</groupId>

--- a/addons/chipgateway/pom.xml
+++ b/addons/chipgateway/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>addons</artifactId>
-		<version>1.4.0-sha1</version>
+		<version>1.4.1-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.addons</groupId>

--- a/addons/chipgateway/pom.xml
+++ b/addons/chipgateway/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>addons</artifactId>
-		<version>1.4.0-rc.5+sha1</version>
+		<version>1.4.0-rc.6-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.addons</groupId>

--- a/addons/genericcryptography/pom.xml
+++ b/addons/genericcryptography/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>addons</artifactId>
-		<version>1.4.0-rc.5-SNAPSHOT</version>
+		<version>1.4.0-rc.5+sha1</version>
 	</parent>
 
 	<groupId>org.openecard.addons</groupId>

--- a/addons/genericcryptography/pom.xml
+++ b/addons/genericcryptography/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>addons</artifactId>
-		<version>1.4.0-rc.6-SNAPSHOT</version>
+		<version>1.4.0-sha1</version>
 	</parent>
 
 	<groupId>org.openecard.addons</groupId>

--- a/addons/genericcryptography/pom.xml
+++ b/addons/genericcryptography/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>addons</artifactId>
-		<version>1.4.0-sha1</version>
+		<version>1.4.1-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.addons</groupId>

--- a/addons/genericcryptography/pom.xml
+++ b/addons/genericcryptography/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>addons</artifactId>
-		<version>1.4.0-rc.5+sha1</version>
+		<version>1.4.0-rc.6-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.addons</groupId>

--- a/addons/pin-management/pom.xml
+++ b/addons/pin-management/pom.xml
@@ -5,7 +5,7 @@
     <parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>addons</artifactId>
-		<version>1.4.0-rc.5+sha1</version>
+		<version>1.4.0-rc.6-SNAPSHOT</version>
     </parent>
 
     <groupId>org.openecard.addons</groupId>

--- a/addons/pin-management/pom.xml
+++ b/addons/pin-management/pom.xml
@@ -5,7 +5,7 @@
     <parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>addons</artifactId>
-		<version>1.4.0-rc.6-SNAPSHOT</version>
+		<version>1.4.0-sha1</version>
     </parent>
 
     <groupId>org.openecard.addons</groupId>

--- a/addons/pin-management/pom.xml
+++ b/addons/pin-management/pom.xml
@@ -5,7 +5,7 @@
     <parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>addons</artifactId>
-		<version>1.4.0-sha1</version>
+		<version>1.4.1-SNAPSHOT</version>
     </parent>
 
     <groupId>org.openecard.addons</groupId>

--- a/addons/pin-management/pom.xml
+++ b/addons/pin-management/pom.xml
@@ -5,7 +5,7 @@
     <parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>addons</artifactId>
-		<version>1.4.0-rc.5-SNAPSHOT</version>
+		<version>1.4.0-rc.5+sha1</version>
     </parent>
 
     <groupId>org.openecard.addons</groupId>

--- a/addons/pom.xml
+++ b/addons/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-sha1</version>
+		<version>1.4.1-SNAPSHOT</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/addons/pom.xml
+++ b/addons/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-rc.5-SNAPSHOT</version>
+		<version>1.4.0-rc.5+sha1</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/addons/pom.xml
+++ b/addons/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-rc.5+sha1</version>
+		<version>1.4.0-rc.6-SNAPSHOT</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/addons/pom.xml
+++ b/addons/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-rc.6-SNAPSHOT</version>
+		<version>1.4.0-sha1</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/addons/status/pom.xml
+++ b/addons/status/pom.xml
@@ -5,7 +5,7 @@
     <parent>
 	<groupId>org.openecard</groupId>
 	<artifactId>addons</artifactId>
-	<version>1.4.0-sha1</version>
+	<version>1.4.1-SNAPSHOT</version>
     </parent>
 
     <groupId>org.openecard.addons</groupId>

--- a/addons/status/pom.xml
+++ b/addons/status/pom.xml
@@ -5,7 +5,7 @@
     <parent>
 	<groupId>org.openecard</groupId>
 	<artifactId>addons</artifactId>
-	<version>1.4.0-rc.5+sha1</version>
+	<version>1.4.0-rc.6-SNAPSHOT</version>
     </parent>
 
     <groupId>org.openecard.addons</groupId>

--- a/addons/status/pom.xml
+++ b/addons/status/pom.xml
@@ -5,7 +5,7 @@
     <parent>
 	<groupId>org.openecard</groupId>
 	<artifactId>addons</artifactId>
-	<version>1.4.0-rc.6-SNAPSHOT</version>
+	<version>1.4.0-sha1</version>
     </parent>
 
     <groupId>org.openecard.addons</groupId>

--- a/addons/status/pom.xml
+++ b/addons/status/pom.xml
@@ -5,7 +5,7 @@
     <parent>
 	<groupId>org.openecard</groupId>
 	<artifactId>addons</artifactId>
-	<version>1.4.0-rc.5-SNAPSHOT</version>
+	<version>1.4.0-rc.5+sha1</version>
     </parent>
 
     <groupId>org.openecard.addons</groupId>

--- a/addons/tr03112/pom.xml
+++ b/addons/tr03112/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>addons</artifactId>
-		<version>1.4.0-rc.5-SNAPSHOT</version>
+		<version>1.4.0-rc.5+sha1</version>
 	</parent>
 
 	<groupId>org.openecard.addons</groupId>

--- a/addons/tr03112/pom.xml
+++ b/addons/tr03112/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>addons</artifactId>
-		<version>1.4.0-rc.6-SNAPSHOT</version>
+		<version>1.4.0-sha1</version>
 	</parent>
 
 	<groupId>org.openecard.addons</groupId>

--- a/addons/tr03112/pom.xml
+++ b/addons/tr03112/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>addons</artifactId>
-		<version>1.4.0-sha1</version>
+		<version>1.4.1-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.addons</groupId>

--- a/addons/tr03112/pom.xml
+++ b/addons/tr03112/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>addons</artifactId>
-		<version>1.4.0-rc.5+sha1</version>
+		<version>1.4.0-rc.6-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.addons</groupId>

--- a/bindings/http/pom.xml
+++ b/bindings/http/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>bindings</artifactId>
-		<version>1.4.0-rc.6-SNAPSHOT</version>
+		<version>1.4.0-sha1</version>
 	</parent>
 
 	<groupId>org.openecard.bindings</groupId>

--- a/bindings/http/pom.xml
+++ b/bindings/http/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>bindings</artifactId>
-		<version>1.4.0-sha1</version>
+		<version>1.4.1-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.bindings</groupId>

--- a/bindings/http/pom.xml
+++ b/bindings/http/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>bindings</artifactId>
-		<version>1.4.0-rc.5-SNAPSHOT</version>
+		<version>1.4.0-rc.5+sha1</version>
 	</parent>
 
 	<groupId>org.openecard.bindings</groupId>

--- a/bindings/http/pom.xml
+++ b/bindings/http/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>bindings</artifactId>
-		<version>1.4.0-rc.5+sha1</version>
+		<version>1.4.0-rc.6-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.bindings</groupId>

--- a/bindings/pom.xml
+++ b/bindings/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-sha1</version>
+		<version>1.4.1-SNAPSHOT</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/bindings/pom.xml
+++ b/bindings/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-rc.5-SNAPSHOT</version>
+		<version>1.4.0-rc.5+sha1</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/bindings/pom.xml
+++ b/bindings/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-rc.5+sha1</version>
+		<version>1.4.0-rc.6-SNAPSHOT</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/bindings/pom.xml
+++ b/bindings/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-rc.6-SNAPSHOT</version>
+		<version>1.4.0-sha1</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/cifs/pom.xml
+++ b/cifs/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-sha1</version>
+		<version>1.4.1-SNAPSHOT</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/cifs/pom.xml
+++ b/cifs/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-rc.5-SNAPSHOT</version>
+		<version>1.4.0-rc.5+sha1</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/cifs/pom.xml
+++ b/cifs/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-rc.5+sha1</version>
+		<version>1.4.0-rc.6-SNAPSHOT</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/cifs/pom.xml
+++ b/cifs/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-rc.6-SNAPSHOT</version>
+		<version>1.4.0-sha1</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/clients/android-core/pom.xml
+++ b/clients/android-core/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>clients</artifactId>
-		<version>1.4.0-rc.5+sha1</version>
+		<version>1.4.0-rc.6-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.clients</groupId>

--- a/clients/android-core/pom.xml
+++ b/clients/android-core/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>clients</artifactId>
-		<version>1.4.0-sha1</version>
+		<version>1.4.1-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.clients</groupId>

--- a/clients/android-core/pom.xml
+++ b/clients/android-core/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>clients</artifactId>
-		<version>1.4.0-rc.5-SNAPSHOT</version>
+		<version>1.4.0-rc.5+sha1</version>
 	</parent>
 
 	<groupId>org.openecard.clients</groupId>

--- a/clients/android-core/pom.xml
+++ b/clients/android-core/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>clients</artifactId>
-		<version>1.4.0-rc.6-SNAPSHOT</version>
+		<version>1.4.0-sha1</version>
 	</parent>
 
 	<groupId>org.openecard.clients</groupId>

--- a/clients/android-lib/build.gradle
+++ b/clients/android-lib/build.gradle
@@ -89,7 +89,7 @@ dependencies {
     compileOnly 'com.google.code.findbugs:annotations:3.0.1u2'
 
     // Android Oec-Core
-    bundleImpl "org.openecard.clients:android-core:${version}"
+    bundleImpl files("../android-core/target/android-core-" + version + ".jar") //"org.openecard.clients:android-core:${version}"
 
     // needed or the thing crashes (should be made an api dependecy)
     bundleImpl "javax.jws.jsr181-api:jsr181-api:2.1.1"

--- a/clients/android-lib/pom.xml
+++ b/clients/android-lib/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>clients</artifactId>
-		<version>1.4.0-rc.5+sha1</version>
+		<version>1.4.0-rc.6-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.clients</groupId>

--- a/clients/android-lib/pom.xml
+++ b/clients/android-lib/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>clients</artifactId>
-		<version>1.4.0-sha1</version>
+		<version>1.4.1-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.clients</groupId>

--- a/clients/android-lib/pom.xml
+++ b/clients/android-lib/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>clients</artifactId>
-		<version>1.4.0-rc.5-SNAPSHOT</version>
+		<version>1.4.0-rc.5+sha1</version>
 	</parent>
 
 	<groupId>org.openecard.clients</groupId>

--- a/clients/android-lib/pom.xml
+++ b/clients/android-lib/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>clients</artifactId>
-		<version>1.4.0-rc.6-SNAPSHOT</version>
+		<version>1.4.0-sha1</version>
 	</parent>
 
 	<groupId>org.openecard.clients</groupId>

--- a/clients/pom.xml
+++ b/clients/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-sha1</version>
+		<version>1.4.1-SNAPSHOT</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/clients/pom.xml
+++ b/clients/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-rc.5-SNAPSHOT</version>
+		<version>1.4.0-rc.5+sha1</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/clients/pom.xml
+++ b/clients/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-rc.5+sha1</version>
+		<version>1.4.0-rc.6-SNAPSHOT</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/clients/pom.xml
+++ b/clients/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-rc.6-SNAPSHOT</version>
+		<version>1.4.0-sha1</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/clients/richclient/pom.xml
+++ b/clients/richclient/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>clients</artifactId>
-		<version>1.4.0-rc.5+sha1</version>
+		<version>1.4.0-rc.6-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.clients</groupId>

--- a/clients/richclient/pom.xml
+++ b/clients/richclient/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>clients</artifactId>
-		<version>1.4.0-sha1</version>
+		<version>1.4.1-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.clients</groupId>

--- a/clients/richclient/pom.xml
+++ b/clients/richclient/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>clients</artifactId>
-		<version>1.4.0-rc.5-SNAPSHOT</version>
+		<version>1.4.0-rc.5+sha1</version>
 	</parent>
 
 	<groupId>org.openecard.clients</groupId>

--- a/clients/richclient/pom.xml
+++ b/clients/richclient/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>clients</artifactId>
-		<version>1.4.0-rc.6-SNAPSHOT</version>
+		<version>1.4.0-sha1</version>
 	</parent>
 
 	<groupId>org.openecard.clients</groupId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-sha1</version>
+		<version>1.4.1-SNAPSHOT</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-rc.5-SNAPSHOT</version>
+		<version>1.4.0-rc.5+sha1</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-rc.5+sha1</version>
+		<version>1.4.0-rc.6-SNAPSHOT</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-rc.6-SNAPSHOT</version>
+		<version>1.4.0-sha1</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/crypto/crypto-common/pom.xml
+++ b/crypto/crypto-common/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>crypto</artifactId>
 		<groupId>org.openecard</groupId>
-		<version>1.4.0-rc.5-SNAPSHOT</version>
+		<version>1.4.0-rc.5+sha1</version>
 	</parent>
 
 	<groupId>org.openecard.crypto</groupId>

--- a/crypto/crypto-common/pom.xml
+++ b/crypto/crypto-common/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>crypto</artifactId>
 		<groupId>org.openecard</groupId>
-		<version>1.4.0-rc.5+sha1</version>
+		<version>1.4.0-rc.6-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.crypto</groupId>

--- a/crypto/crypto-common/pom.xml
+++ b/crypto/crypto-common/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>crypto</artifactId>
 		<groupId>org.openecard</groupId>
-		<version>1.4.0-sha1</version>
+		<version>1.4.1-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.crypto</groupId>

--- a/crypto/crypto-common/pom.xml
+++ b/crypto/crypto-common/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>crypto</artifactId>
 		<groupId>org.openecard</groupId>
-		<version>1.4.0-rc.6-SNAPSHOT</version>
+		<version>1.4.0-sha1</version>
 	</parent>
 
 	<groupId>org.openecard.crypto</groupId>

--- a/crypto/pom.xml
+++ b/crypto/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-sha1</version>
+		<version>1.4.1-SNAPSHOT</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/crypto/pom.xml
+++ b/crypto/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-rc.5-SNAPSHOT</version>
+		<version>1.4.0-rc.5+sha1</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/crypto/pom.xml
+++ b/crypto/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-rc.5+sha1</version>
+		<version>1.4.0-rc.6-SNAPSHOT</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/crypto/pom.xml
+++ b/crypto/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-rc.6-SNAPSHOT</version>
+		<version>1.4.0-sha1</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/crypto/tls/pom.xml
+++ b/crypto/tls/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>crypto</artifactId>
-		<version>1.4.0-rc.6-SNAPSHOT</version>
+		<version>1.4.0-sha1</version>
 	</parent>
 
 	<groupId>org.openecard.crypto</groupId>

--- a/crypto/tls/pom.xml
+++ b/crypto/tls/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>crypto</artifactId>
-		<version>1.4.0-rc.5+sha1</version>
+		<version>1.4.0-rc.6-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.crypto</groupId>

--- a/crypto/tls/pom.xml
+++ b/crypto/tls/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>crypto</artifactId>
-		<version>1.4.0-sha1</version>
+		<version>1.4.1-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.crypto</groupId>

--- a/crypto/tls/pom.xml
+++ b/crypto/tls/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>crypto</artifactId>
-		<version>1.4.0-rc.5-SNAPSHOT</version>
+		<version>1.4.0-rc.5+sha1</version>
 	</parent>
 
 	<groupId>org.openecard.crypto</groupId>

--- a/crypto/tls/src/main/java/org/openecard/crypto/tls/ClientCertDefaultTlsClient.java
+++ b/crypto/tls/src/main/java/org/openecard/crypto/tls/ClientCertDefaultTlsClient.java
@@ -253,7 +253,7 @@ public class ClientCertDefaultTlsClient extends DefaultTlsClient implements Clie
     protected Vector getSupportedSignatureAlgorithms() {
 	TlsCrypto crypto = context.getCrypto();
         short[] hashAlgorithms = new short[]{HashAlgorithm.sha512, HashAlgorithm.sha384, HashAlgorithm.sha256,
-	    HashAlgorithm.sha224, HashAlgorithm.sha1};
+	    HashAlgorithm.sha224};
         short[] signatureAlgorithms = new short[]{ SignatureAlgorithm.rsa, SignatureAlgorithm.ecdsa };
 
         Vector result = new Vector();

--- a/crypto/tls/src/main/java/org/openecard/crypto/tls/ClientCertDefaultTlsClient.java
+++ b/crypto/tls/src/main/java/org/openecard/crypto/tls/ClientCertDefaultTlsClient.java
@@ -253,7 +253,7 @@ public class ClientCertDefaultTlsClient extends DefaultTlsClient implements Clie
     protected Vector getSupportedSignatureAlgorithms() {
 	TlsCrypto crypto = context.getCrypto();
         short[] hashAlgorithms = new short[]{HashAlgorithm.sha512, HashAlgorithm.sha384, HashAlgorithm.sha256,
-	    HashAlgorithm.sha224};
+	    HashAlgorithm.sha224, HashAlgorithm.sha1};
         short[] signatureAlgorithms = new short[]{ SignatureAlgorithm.rsa, SignatureAlgorithm.ecdsa };
 
         Vector result = new Vector();

--- a/gui/about/pom.xml
+++ b/gui/about/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>gui</artifactId>
-		<version>1.4.0-sha1</version>
+		<version>1.4.1-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.gui</groupId>

--- a/gui/about/pom.xml
+++ b/gui/about/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>gui</artifactId>
-		<version>1.4.0-rc.5+sha1</version>
+		<version>1.4.0-rc.6-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.gui</groupId>

--- a/gui/about/pom.xml
+++ b/gui/about/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>gui</artifactId>
-		<version>1.4.0-rc.6-SNAPSHOT</version>
+		<version>1.4.0-sha1</version>
 	</parent>
 
 	<groupId>org.openecard.gui</groupId>

--- a/gui/about/pom.xml
+++ b/gui/about/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>gui</artifactId>
-		<version>1.4.0-rc.5-SNAPSHOT</version>
+		<version>1.4.0-rc.5+sha1</version>
 	</parent>
 
 	<groupId>org.openecard.gui</groupId>

--- a/gui/android/pom.xml
+++ b/gui/android/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>gui</artifactId>
-		<version>1.4.0-sha1</version>
+		<version>1.4.1-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.gui</groupId>

--- a/gui/android/pom.xml
+++ b/gui/android/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>gui</artifactId>
-		<version>1.4.0-rc.5+sha1</version>
+		<version>1.4.0-rc.6-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.gui</groupId>

--- a/gui/android/pom.xml
+++ b/gui/android/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>gui</artifactId>
-		<version>1.4.0-rc.6-SNAPSHOT</version>
+		<version>1.4.0-sha1</version>
 	</parent>
 
 	<groupId>org.openecard.gui</groupId>

--- a/gui/android/pom.xml
+++ b/gui/android/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>gui</artifactId>
-		<version>1.4.0-rc.5-SNAPSHOT</version>
+		<version>1.4.0-rc.5+sha1</version>
 	</parent>
 
 	<groupId>org.openecard.gui</groupId>

--- a/gui/graphics/pom.xml
+++ b/gui/graphics/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>gui</artifactId>
-		<version>1.4.0-sha1</version>
+		<version>1.4.1-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.gui</groupId>

--- a/gui/graphics/pom.xml
+++ b/gui/graphics/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>gui</artifactId>
-		<version>1.4.0-rc.5+sha1</version>
+		<version>1.4.0-rc.6-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.gui</groupId>

--- a/gui/graphics/pom.xml
+++ b/gui/graphics/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>gui</artifactId>
-		<version>1.4.0-rc.6-SNAPSHOT</version>
+		<version>1.4.0-sha1</version>
 	</parent>
 
 	<groupId>org.openecard.gui</groupId>

--- a/gui/graphics/pom.xml
+++ b/gui/graphics/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>gui</artifactId>
-		<version>1.4.0-rc.5-SNAPSHOT</version>
+		<version>1.4.0-rc.5+sha1</version>
 	</parent>
 
 	<groupId>org.openecard.gui</groupId>

--- a/gui/gui-common/pom.xml
+++ b/gui/gui-common/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>gui</artifactId>
-		<version>1.4.0-sha1</version>
+		<version>1.4.1-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.gui</groupId>

--- a/gui/gui-common/pom.xml
+++ b/gui/gui-common/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>gui</artifactId>
-		<version>1.4.0-rc.5+sha1</version>
+		<version>1.4.0-rc.6-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.gui</groupId>

--- a/gui/gui-common/pom.xml
+++ b/gui/gui-common/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>gui</artifactId>
-		<version>1.4.0-rc.6-SNAPSHOT</version>
+		<version>1.4.0-sha1</version>
 	</parent>
 
 	<groupId>org.openecard.gui</groupId>

--- a/gui/gui-common/pom.xml
+++ b/gui/gui-common/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>gui</artifactId>
-		<version>1.4.0-rc.5-SNAPSHOT</version>
+		<version>1.4.0-rc.5+sha1</version>
 	</parent>
 
 	<groupId>org.openecard.gui</groupId>

--- a/gui/pom.xml
+++ b/gui/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-sha1</version>
+		<version>1.4.1-SNAPSHOT</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/gui/pom.xml
+++ b/gui/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-rc.5-SNAPSHOT</version>
+		<version>1.4.0-rc.5+sha1</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/gui/pom.xml
+++ b/gui/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-rc.5+sha1</version>
+		<version>1.4.0-rc.6-SNAPSHOT</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/gui/pom.xml
+++ b/gui/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-rc.6-SNAPSHOT</version>
+		<version>1.4.0-sha1</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/gui/swing/pom.xml
+++ b/gui/swing/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>gui</artifactId>
-		<version>1.4.0-sha1</version>
+		<version>1.4.1-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.gui</groupId>

--- a/gui/swing/pom.xml
+++ b/gui/swing/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>gui</artifactId>
-		<version>1.4.0-rc.5+sha1</version>
+		<version>1.4.0-rc.6-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.gui</groupId>

--- a/gui/swing/pom.xml
+++ b/gui/swing/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>gui</artifactId>
-		<version>1.4.0-rc.6-SNAPSHOT</version>
+		<version>1.4.0-sha1</version>
 	</parent>
 
 	<groupId>org.openecard.gui</groupId>

--- a/gui/swing/pom.xml
+++ b/gui/swing/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>gui</artifactId>
-		<version>1.4.0-rc.5-SNAPSHOT</version>
+		<version>1.4.0-rc.5+sha1</version>
 	</parent>
 
 	<groupId>org.openecard.gui</groupId>

--- a/i18n/pom.xml
+++ b/i18n/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-sha1</version>
+		<version>1.4.1-SNAPSHOT</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/i18n/pom.xml
+++ b/i18n/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-rc.5-SNAPSHOT</version>
+		<version>1.4.0-rc.5+sha1</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/i18n/pom.xml
+++ b/i18n/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-rc.5+sha1</version>
+		<version>1.4.0-rc.6-SNAPSHOT</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/i18n/pom.xml
+++ b/i18n/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-rc.6-SNAPSHOT</version>
+		<version>1.4.0-sha1</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/ifd/ifd-common/pom.xml
+++ b/ifd/ifd-common/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>ifd</artifactId>
-		<version>1.4.0-rc.5+sha1</version>
+		<version>1.4.0-rc.6-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.ifd</groupId>

--- a/ifd/ifd-common/pom.xml
+++ b/ifd/ifd-common/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>ifd</artifactId>
-		<version>1.4.0-rc.5-SNAPSHOT</version>
+		<version>1.4.0-rc.5+sha1</version>
 	</parent>
 
 	<groupId>org.openecard.ifd</groupId>

--- a/ifd/ifd-common/pom.xml
+++ b/ifd/ifd-common/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>ifd</artifactId>
-		<version>1.4.0-sha1</version>
+		<version>1.4.1-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.ifd</groupId>

--- a/ifd/ifd-common/pom.xml
+++ b/ifd/ifd-common/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>ifd</artifactId>
-		<version>1.4.0-rc.6-SNAPSHOT</version>
+		<version>1.4.0-sha1</version>
 	</parent>
 
 	<groupId>org.openecard.ifd</groupId>

--- a/ifd/ifd-core/pom.xml
+++ b/ifd/ifd-core/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>ifd</artifactId>
-		<version>1.4.0-rc.5+sha1</version>
+		<version>1.4.0-rc.6-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.ifd</groupId>

--- a/ifd/ifd-core/pom.xml
+++ b/ifd/ifd-core/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>ifd</artifactId>
-		<version>1.4.0-rc.5-SNAPSHOT</version>
+		<version>1.4.0-rc.5+sha1</version>
 	</parent>
 
 	<groupId>org.openecard.ifd</groupId>

--- a/ifd/ifd-core/pom.xml
+++ b/ifd/ifd-core/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>ifd</artifactId>
-		<version>1.4.0-sha1</version>
+		<version>1.4.1-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.ifd</groupId>

--- a/ifd/ifd-core/pom.xml
+++ b/ifd/ifd-core/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>ifd</artifactId>
-		<version>1.4.0-rc.6-SNAPSHOT</version>
+		<version>1.4.0-sha1</version>
 	</parent>
 
 	<groupId>org.openecard.ifd</groupId>

--- a/ifd/ifd-protocols/pace/pom.xml
+++ b/ifd/ifd-protocols/pace/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard.ifd</groupId>
 		<artifactId>ifd-protocols</artifactId>
-		<version>1.4.0-sha1</version>
+		<version>1.4.1-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.ifd.protocols</groupId>

--- a/ifd/ifd-protocols/pace/pom.xml
+++ b/ifd/ifd-protocols/pace/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard.ifd</groupId>
 		<artifactId>ifd-protocols</artifactId>
-		<version>1.4.0-rc.5+sha1</version>
+		<version>1.4.0-rc.6-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.ifd.protocols</groupId>

--- a/ifd/ifd-protocols/pace/pom.xml
+++ b/ifd/ifd-protocols/pace/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard.ifd</groupId>
 		<artifactId>ifd-protocols</artifactId>
-		<version>1.4.0-rc.5-SNAPSHOT</version>
+		<version>1.4.0-rc.5+sha1</version>
 	</parent>
 
 	<groupId>org.openecard.ifd.protocols</groupId>

--- a/ifd/ifd-protocols/pace/pom.xml
+++ b/ifd/ifd-protocols/pace/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard.ifd</groupId>
 		<artifactId>ifd-protocols</artifactId>
-		<version>1.4.0-rc.6-SNAPSHOT</version>
+		<version>1.4.0-sha1</version>
 	</parent>
 
 	<groupId>org.openecard.ifd.protocols</groupId>

--- a/ifd/ifd-protocols/pom.xml
+++ b/ifd/ifd-protocols/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>ifd</artifactId>
-		<version>1.4.0-rc.5+sha1</version>
+		<version>1.4.0-rc.6-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.ifd</groupId>

--- a/ifd/ifd-protocols/pom.xml
+++ b/ifd/ifd-protocols/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>ifd</artifactId>
-		<version>1.4.0-rc.5-SNAPSHOT</version>
+		<version>1.4.0-rc.5+sha1</version>
 	</parent>
 
 	<groupId>org.openecard.ifd</groupId>

--- a/ifd/ifd-protocols/pom.xml
+++ b/ifd/ifd-protocols/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>ifd</artifactId>
-		<version>1.4.0-sha1</version>
+		<version>1.4.1-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.ifd</groupId>

--- a/ifd/ifd-protocols/pom.xml
+++ b/ifd/ifd-protocols/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>ifd</artifactId>
-		<version>1.4.0-rc.6-SNAPSHOT</version>
+		<version>1.4.0-sha1</version>
 	</parent>
 
 	<groupId>org.openecard.ifd</groupId>

--- a/ifd/pom.xml
+++ b/ifd/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-sha1</version>
+		<version>1.4.1-SNAPSHOT</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/ifd/pom.xml
+++ b/ifd/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-rc.5-SNAPSHOT</version>
+		<version>1.4.0-rc.5+sha1</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/ifd/pom.xml
+++ b/ifd/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-rc.5+sha1</version>
+		<version>1.4.0-rc.6-SNAPSHOT</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/ifd/pom.xml
+++ b/ifd/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-rc.6-SNAPSHOT</version>
+		<version>1.4.0-sha1</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/ifd/scio-backend/android-nfc/pom.xml
+++ b/ifd/scio-backend/android-nfc/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard.ifd</groupId>
 		<artifactId>scio-backend</artifactId>
-		<version>1.4.0-rc.5+sha1</version>
+		<version>1.4.0-rc.6-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.ifd.scio-backend</groupId>

--- a/ifd/scio-backend/android-nfc/pom.xml
+++ b/ifd/scio-backend/android-nfc/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard.ifd</groupId>
 		<artifactId>scio-backend</artifactId>
-		<version>1.4.0-rc.6-SNAPSHOT</version>
+		<version>1.4.0-sha1</version>
 	</parent>
 
 	<groupId>org.openecard.ifd.scio-backend</groupId>

--- a/ifd/scio-backend/android-nfc/pom.xml
+++ b/ifd/scio-backend/android-nfc/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard.ifd</groupId>
 		<artifactId>scio-backend</artifactId>
-		<version>1.4.0-rc.5-SNAPSHOT</version>
+		<version>1.4.0-rc.5+sha1</version>
 	</parent>
 
 	<groupId>org.openecard.ifd.scio-backend</groupId>

--- a/ifd/scio-backend/android-nfc/pom.xml
+++ b/ifd/scio-backend/android-nfc/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard.ifd</groupId>
 		<artifactId>scio-backend</artifactId>
-		<version>1.4.0-sha1</version>
+		<version>1.4.1-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.ifd.scio-backend</groupId>

--- a/ifd/scio-backend/pcsc/pom.xml
+++ b/ifd/scio-backend/pcsc/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard.ifd</groupId>
 		<artifactId>scio-backend</artifactId>
-		<version>1.4.0-rc.5+sha1</version>
+		<version>1.4.0-rc.6-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.ifd.scio-backend</groupId>

--- a/ifd/scio-backend/pcsc/pom.xml
+++ b/ifd/scio-backend/pcsc/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard.ifd</groupId>
 		<artifactId>scio-backend</artifactId>
-		<version>1.4.0-rc.6-SNAPSHOT</version>
+		<version>1.4.0-sha1</version>
 	</parent>
 
 	<groupId>org.openecard.ifd.scio-backend</groupId>

--- a/ifd/scio-backend/pcsc/pom.xml
+++ b/ifd/scio-backend/pcsc/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard.ifd</groupId>
 		<artifactId>scio-backend</artifactId>
-		<version>1.4.0-rc.5-SNAPSHOT</version>
+		<version>1.4.0-rc.5+sha1</version>
 	</parent>
 
 	<groupId>org.openecard.ifd.scio-backend</groupId>

--- a/ifd/scio-backend/pcsc/pom.xml
+++ b/ifd/scio-backend/pcsc/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard.ifd</groupId>
 		<artifactId>scio-backend</artifactId>
-		<version>1.4.0-sha1</version>
+		<version>1.4.1-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.ifd.scio-backend</groupId>

--- a/ifd/scio-backend/pom.xml
+++ b/ifd/scio-backend/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>ifd</artifactId>
-		<version>1.4.0-rc.5+sha1</version>
+		<version>1.4.0-rc.6-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.ifd</groupId>

--- a/ifd/scio-backend/pom.xml
+++ b/ifd/scio-backend/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>ifd</artifactId>
-		<version>1.4.0-rc.5-SNAPSHOT</version>
+		<version>1.4.0-rc.5+sha1</version>
 	</parent>
 
 	<groupId>org.openecard.ifd</groupId>

--- a/ifd/scio-backend/pom.xml
+++ b/ifd/scio-backend/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>ifd</artifactId>
-		<version>1.4.0-sha1</version>
+		<version>1.4.1-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.ifd</groupId>

--- a/ifd/scio-backend/pom.xml
+++ b/ifd/scio-backend/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>ifd</artifactId>
-		<version>1.4.0-rc.6-SNAPSHOT</version>
+		<version>1.4.0-sha1</version>
 	</parent>
 
 	<groupId>org.openecard.ifd</groupId>

--- a/management/pom.xml
+++ b/management/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-sha1</version>
+		<version>1.4.1-SNAPSHOT</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/management/pom.xml
+++ b/management/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-rc.5-SNAPSHOT</version>
+		<version>1.4.0-rc.5+sha1</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/management/pom.xml
+++ b/management/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-rc.5+sha1</version>
+		<version>1.4.0-rc.6-SNAPSHOT</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/management/pom.xml
+++ b/management/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-rc.6-SNAPSHOT</version>
+		<version>1.4.0-sha1</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/packager/pom.xml
+++ b/packager/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>app</artifactId>
-		<version>1.4.0-rc.6-SNAPSHOT</version>
+		<version>1.4.0-sha1</version>
 	</parent>
 
 	<groupId>org.openecard</groupId>

--- a/packager/pom.xml
+++ b/packager/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>app</artifactId>
-		<version>1.4.0-sha1</version>
+		<version>1.4.1-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard</groupId>

--- a/packager/pom.xml
+++ b/packager/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>app</artifactId>
-		<version>1.4.0-rc.5-SNAPSHOT</version>
+		<version>1.4.0-rc.5+sha1</version>
 	</parent>
 
 	<groupId>org.openecard</groupId>

--- a/packager/pom.xml
+++ b/packager/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>app</artifactId>
-		<version>1.4.0-rc.5+sha1</version>
+		<version>1.4.0-rc.6-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard</groupId>

--- a/packager/richclient-bundle/pom.xml
+++ b/packager/richclient-bundle/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>packager</artifactId>
-		<version>1.4.0-rc.5+sha1</version>
+		<version>1.4.0-rc.6-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.clients</groupId>

--- a/packager/richclient-bundle/pom.xml
+++ b/packager/richclient-bundle/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>packager</artifactId>
-		<version>1.4.0-rc.5-SNAPSHOT</version>
+		<version>1.4.0-rc.5+sha1</version>
 	</parent>
 
 	<groupId>org.openecard.clients</groupId>

--- a/packager/richclient-bundle/pom.xml
+++ b/packager/richclient-bundle/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>packager</artifactId>
-		<version>1.4.0-rc.6-SNAPSHOT</version>
+		<version>1.4.0-sha1</version>
 	</parent>
 
 	<groupId>org.openecard.clients</groupId>

--- a/packager/richclient-bundle/pom.xml
+++ b/packager/richclient-bundle/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>packager</artifactId>
-		<version>1.4.0-sha1</version>
+		<version>1.4.1-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.clients</groupId>

--- a/packager/richclient-bundle/pom.xml
+++ b/packager/richclient-bundle/pom.xml
@@ -23,6 +23,14 @@
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-assembly-plugin</artifactId>
 				<configuration>
 					<appendAssemblyId>false</appendAssemblyId>

--- a/packager/richclient-packager/pom.xml
+++ b/packager/richclient-packager/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>packager</artifactId>
-		<version>1.4.0-rc.5+sha1</version>
+		<version>1.4.0-rc.6-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.clients</groupId>

--- a/packager/richclient-packager/pom.xml
+++ b/packager/richclient-packager/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>packager</artifactId>
-		<version>1.4.0-rc.5-SNAPSHOT</version>
+		<version>1.4.0-rc.5+sha1</version>
 	</parent>
 
 	<groupId>org.openecard.clients</groupId>

--- a/packager/richclient-packager/pom.xml
+++ b/packager/richclient-packager/pom.xml
@@ -244,6 +244,14 @@
 
 	<build>
 		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
+			</plugin>
+
 			<!-- Plugin to reuse project version for installers -->
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>

--- a/packager/richclient-packager/pom.xml
+++ b/packager/richclient-packager/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>packager</artifactId>
-		<version>1.4.0-rc.6-SNAPSHOT</version>
+		<version>1.4.0-sha1</version>
 	</parent>
 
 	<groupId>org.openecard.clients</groupId>

--- a/packager/richclient-packager/pom.xml
+++ b/packager/richclient-packager/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>packager</artifactId>
-		<version>1.4.0-sha1</version>
+		<version>1.4.1-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.clients</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.openecard</groupId>
 	<artifactId>app</artifactId>
 	<packaging>pom</packaging>
-	<version>1.4.0-rc.5+sha1</version>
+	<version>1.4.0-rc.6-SNAPSHOT</version>
 	<name>Open eCard Client</name>
 
 	<url>http://www.openecard.org/</url>
@@ -20,7 +20,7 @@
 		<connection>scm:git:https://github.com/ecsec/open-ecard.git</connection>
 		<developerConnection>scm:git:ssh://git@github.com/ecsec/open-ecard.git</developerConnection>
 		<url>https://github.com/ecsec/open-ecard</url>
-		<tag>1.4.0-rc.5+sha1</tag>
+		<tag>1.2.4</tag>
 	</scm>
 	<ciManagement>
 		<system>Jenkins CI</system>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.openecard</groupId>
 	<artifactId>app</artifactId>
 	<packaging>pom</packaging>
-	<version>1.4.0-sha1</version>
+	<version>1.4.1-SNAPSHOT</version>
 	<name>Open eCard Client</name>
 
 	<url>http://www.openecard.org/</url>
@@ -20,7 +20,7 @@
 		<connection>scm:git:https://github.com/ecsec/open-ecard.git</connection>
 		<developerConnection>scm:git:ssh://git@github.com/ecsec/open-ecard.git</developerConnection>
 		<url>https://github.com/ecsec/open-ecard</url>
-		<tag>1.4.0-sha1</tag>
+		<tag>1.2.4</tag>
 	</scm>
 	<ciManagement>
 		<system>Jenkins CI</system>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.openecard</groupId>
 	<artifactId>app</artifactId>
 	<packaging>pom</packaging>
-	<version>1.4.0-rc.6-SNAPSHOT</version>
+	<version>1.4.0-sha1</version>
 	<name>Open eCard Client</name>
 
 	<url>http://www.openecard.org/</url>
@@ -20,7 +20,7 @@
 		<connection>scm:git:https://github.com/ecsec/open-ecard.git</connection>
 		<developerConnection>scm:git:ssh://git@github.com/ecsec/open-ecard.git</developerConnection>
 		<url>https://github.com/ecsec/open-ecard</url>
-		<tag>1.2.4</tag>
+		<tag>1.4.0-sha1</tag>
 	</scm>
 	<ciManagement>
 		<system>Jenkins CI</system>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.openecard</groupId>
 	<artifactId>app</artifactId>
 	<packaging>pom</packaging>
-	<version>1.4.0-rc.5-SNAPSHOT</version>
+	<version>1.4.0-rc.5+sha1</version>
 	<name>Open eCard Client</name>
 
 	<url>http://www.openecard.org/</url>
@@ -20,7 +20,7 @@
 		<connection>scm:git:https://github.com/ecsec/open-ecard.git</connection>
 		<developerConnection>scm:git:ssh://git@github.com/ecsec/open-ecard.git</developerConnection>
 		<url>https://github.com/ecsec/open-ecard</url>
-		<tag>1.2.4</tag>
+		<tag>1.4.0-rc.5+sha1</tag>
 	</scm>
 	<ciManagement>
 		<system>Jenkins CI</system>

--- a/recognition/pom.xml
+++ b/recognition/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-sha1</version>
+		<version>1.4.1-SNAPSHOT</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/recognition/pom.xml
+++ b/recognition/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-rc.5-SNAPSHOT</version>
+		<version>1.4.0-rc.5+sha1</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/recognition/pom.xml
+++ b/recognition/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-rc.5+sha1</version>
+		<version>1.4.0-rc.6-SNAPSHOT</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/recognition/pom.xml
+++ b/recognition/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-rc.6-SNAPSHOT</version>
+		<version>1.4.0-sha1</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/sal/middleware-sal/pom.xml
+++ b/sal/middleware-sal/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>sal</artifactId>
-		<version>1.4.0-sha1</version>
+		<version>1.4.1-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.sal</groupId>

--- a/sal/middleware-sal/pom.xml
+++ b/sal/middleware-sal/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>sal</artifactId>
-		<version>1.4.0-rc.6-SNAPSHOT</version>
+		<version>1.4.0-sha1</version>
 	</parent>
 
 	<groupId>org.openecard.sal</groupId>

--- a/sal/middleware-sal/pom.xml
+++ b/sal/middleware-sal/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>sal</artifactId>
-		<version>1.4.0-rc.5-SNAPSHOT</version>
+		<version>1.4.0-rc.5+sha1</version>
 	</parent>
 
 	<groupId>org.openecard.sal</groupId>

--- a/sal/middleware-sal/pom.xml
+++ b/sal/middleware-sal/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>sal</artifactId>
-		<version>1.4.0-rc.5+sha1</version>
+		<version>1.4.0-rc.6-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.sal</groupId>

--- a/sal/pom.xml
+++ b/sal/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-sha1</version>
+		<version>1.4.1-SNAPSHOT</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/sal/pom.xml
+++ b/sal/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-rc.5-SNAPSHOT</version>
+		<version>1.4.0-rc.5+sha1</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/sal/pom.xml
+++ b/sal/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-rc.5+sha1</version>
+		<version>1.4.0-rc.6-SNAPSHOT</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/sal/pom.xml
+++ b/sal/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-rc.6-SNAPSHOT</version>
+		<version>1.4.0-sha1</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/sal/sal-common/pom.xml
+++ b/sal/sal-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>sal</artifactId>
-		<version>1.4.0-rc.5-SNAPSHOT</version>
+		<version>1.4.0-rc.5+sha1</version>
     </parent>
 
 	<groupId>org.openecard.sal</groupId>

--- a/sal/sal-common/pom.xml
+++ b/sal/sal-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>sal</artifactId>
-		<version>1.4.0-rc.6-SNAPSHOT</version>
+		<version>1.4.0-sha1</version>
     </parent>
 
 	<groupId>org.openecard.sal</groupId>

--- a/sal/sal-common/pom.xml
+++ b/sal/sal-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>sal</artifactId>
-		<version>1.4.0-sha1</version>
+		<version>1.4.1-SNAPSHOT</version>
     </parent>
 
 	<groupId>org.openecard.sal</groupId>

--- a/sal/sal-common/pom.xml
+++ b/sal/sal-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>sal</artifactId>
-		<version>1.4.0-rc.5+sha1</version>
+		<version>1.4.0-rc.6-SNAPSHOT</version>
     </parent>
 
 	<groupId>org.openecard.sal</groupId>

--- a/sal/tiny-sal/pom.xml
+++ b/sal/tiny-sal/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>sal</artifactId>
-		<version>1.4.0-sha1</version>
+		<version>1.4.1-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.sal</groupId>

--- a/sal/tiny-sal/pom.xml
+++ b/sal/tiny-sal/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>sal</artifactId>
-		<version>1.4.0-rc.6-SNAPSHOT</version>
+		<version>1.4.0-sha1</version>
 	</parent>
 
 	<groupId>org.openecard.sal</groupId>

--- a/sal/tiny-sal/pom.xml
+++ b/sal/tiny-sal/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>sal</artifactId>
-		<version>1.4.0-rc.5-SNAPSHOT</version>
+		<version>1.4.0-rc.5+sha1</version>
 	</parent>
 
 	<groupId>org.openecard.sal</groupId>

--- a/sal/tiny-sal/pom.xml
+++ b/sal/tiny-sal/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>sal</artifactId>
-		<version>1.4.0-rc.5+sha1</version>
+		<version>1.4.0-rc.6-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.sal</groupId>

--- a/src-parent/pom.xml
+++ b/src-parent/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>app</artifactId>
-		<version>1.4.0-rc.5+sha1</version>
+		<version>1.4.0-rc.6-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard</groupId>

--- a/src-parent/pom.xml
+++ b/src-parent/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>app</artifactId>
-		<version>1.4.0-rc.5-SNAPSHOT</version>
+		<version>1.4.0-rc.5+sha1</version>
 	</parent>
 
 	<groupId>org.openecard</groupId>

--- a/src-parent/pom.xml
+++ b/src-parent/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>app</artifactId>
-		<version>1.4.0-rc.6-SNAPSHOT</version>
+		<version>1.4.0-sha1</version>
 	</parent>
 
 	<groupId>org.openecard</groupId>

--- a/src-parent/pom.xml
+++ b/src-parent/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>app</artifactId>
-		<version>1.4.0-sha1</version>
+		<version>1.4.1-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard</groupId>

--- a/wsdef/android-marshaller/pom.xml
+++ b/wsdef/android-marshaller/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>wsdef</artifactId>
-		<version>1.4.0-sha1</version>
+		<version>1.4.1-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.wsdef</groupId>

--- a/wsdef/android-marshaller/pom.xml
+++ b/wsdef/android-marshaller/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>wsdef</artifactId>
-		<version>1.4.0-rc.5+sha1</version>
+		<version>1.4.0-rc.6-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.wsdef</groupId>

--- a/wsdef/android-marshaller/pom.xml
+++ b/wsdef/android-marshaller/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>wsdef</artifactId>
-		<version>1.4.0-rc.5-SNAPSHOT</version>
+		<version>1.4.0-rc.5+sha1</version>
 	</parent>
 
 	<groupId>org.openecard.wsdef</groupId>

--- a/wsdef/android-marshaller/pom.xml
+++ b/wsdef/android-marshaller/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>wsdef</artifactId>
-		<version>1.4.0-rc.6-SNAPSHOT</version>
+		<version>1.4.0-sha1</version>
 	</parent>
 
 	<groupId>org.openecard.wsdef</groupId>

--- a/wsdef/jaxb-marshaller/pom.xml
+++ b/wsdef/jaxb-marshaller/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>wsdef</artifactId>
-		<version>1.4.0-sha1</version>
+		<version>1.4.1-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.wsdef</groupId>

--- a/wsdef/jaxb-marshaller/pom.xml
+++ b/wsdef/jaxb-marshaller/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>wsdef</artifactId>
-		<version>1.4.0-rc.5+sha1</version>
+		<version>1.4.0-rc.6-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.wsdef</groupId>

--- a/wsdef/jaxb-marshaller/pom.xml
+++ b/wsdef/jaxb-marshaller/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>wsdef</artifactId>
-		<version>1.4.0-rc.5-SNAPSHOT</version>
+		<version>1.4.0-rc.5+sha1</version>
 	</parent>
 
 	<groupId>org.openecard.wsdef</groupId>

--- a/wsdef/jaxb-marshaller/pom.xml
+++ b/wsdef/jaxb-marshaller/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>wsdef</artifactId>
-		<version>1.4.0-rc.6-SNAPSHOT</version>
+		<version>1.4.0-sha1</version>
 	</parent>
 
 	<groupId>org.openecard.wsdef</groupId>

--- a/wsdef/pom.xml
+++ b/wsdef/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-sha1</version>
+		<version>1.4.1-SNAPSHOT</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/wsdef/pom.xml
+++ b/wsdef/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-rc.5-SNAPSHOT</version>
+		<version>1.4.0-rc.5+sha1</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/wsdef/pom.xml
+++ b/wsdef/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-rc.5+sha1</version>
+		<version>1.4.0-rc.6-SNAPSHOT</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/wsdef/pom.xml
+++ b/wsdef/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>src-parent</artifactId>
-		<version>1.4.0-rc.6-SNAPSHOT</version>
+		<version>1.4.0-sha1</version>
 		<relativePath>../src-parent/</relativePath>
 	</parent>
 

--- a/wsdef/wsdef-client/pom.xml
+++ b/wsdef/wsdef-client/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>wsdef</artifactId>
-		<version>1.4.0-sha1</version>
+		<version>1.4.1-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.wsdef</groupId>

--- a/wsdef/wsdef-client/pom.xml
+++ b/wsdef/wsdef-client/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>wsdef</artifactId>
-		<version>1.4.0-rc.5+sha1</version>
+		<version>1.4.0-rc.6-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.wsdef</groupId>

--- a/wsdef/wsdef-client/pom.xml
+++ b/wsdef/wsdef-client/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>wsdef</artifactId>
-		<version>1.4.0-rc.5-SNAPSHOT</version>
+		<version>1.4.0-rc.5+sha1</version>
 	</parent>
 
 	<groupId>org.openecard.wsdef</groupId>

--- a/wsdef/wsdef-client/pom.xml
+++ b/wsdef/wsdef-client/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>wsdef</artifactId>
-		<version>1.4.0-rc.6-SNAPSHOT</version>
+		<version>1.4.0-sha1</version>
 	</parent>
 
 	<groupId>org.openecard.wsdef</groupId>

--- a/wsdef/wsdef-common/pom.xml
+++ b/wsdef/wsdef-common/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>wsdef</artifactId>
-		<version>1.4.0-sha1</version>
+		<version>1.4.1-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.wsdef</groupId>

--- a/wsdef/wsdef-common/pom.xml
+++ b/wsdef/wsdef-common/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>wsdef</artifactId>
-		<version>1.4.0-rc.5+sha1</version>
+		<version>1.4.0-rc.6-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.openecard.wsdef</groupId>

--- a/wsdef/wsdef-common/pom.xml
+++ b/wsdef/wsdef-common/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>wsdef</artifactId>
-		<version>1.4.0-rc.5-SNAPSHOT</version>
+		<version>1.4.0-rc.5+sha1</version>
 	</parent>
 
 	<groupId>org.openecard.wsdef</groupId>

--- a/wsdef/wsdef-common/pom.xml
+++ b/wsdef/wsdef-common/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openecard</groupId>
 		<artifactId>wsdef</artifactId>
-		<version>1.4.0-rc.6-SNAPSHOT</version>
+		<version>1.4.0-sha1</version>
 	</parent>
 
 	<groupId>org.openecard.wsdef</groupId>


### PR DESCRIPTION
We allowed sha1 temporarily for clients on this branch. 
This is taken back in the last commit. 
We have to merge it though, since there are commits on this branch which should be in master. 

Alternatively we could pick 3392c31 and 49f1c2e to master and leave this branch open-ended. 
Which would make this PR superfluous. 