### PR TITLE
Harden against non IsoDep chips

### DIFF
--- a/clients/android-lib/src/main/java/org/openecard/android/ex/NFCTagNotSupported.java
+++ b/clients/android-lib/src/main/java/org/openecard/android/ex/NFCTagNotSupported.java
@@ -1,0 +1,42 @@
+/****************************************************************************
+ * Copyright (C) 2017 ecsec GmbH.
+ * All rights reserved.
+ * Contact: ecsec GmbH (info@ecsec.de)
+ *
+ * This file is part of the Open eCard App.
+ *
+ * GNU General Public License Usage
+ * This file may be used under the terms of the GNU General Public
+ * License version 3.0 as published by the Free Software Foundation
+ * and appearing in the file LICENSE.GPL included in the packaging of
+ * this file. Please review the following information to ensure the
+ * GNU General Public License version 3.0 requirements will be met:
+ * http://www.gnu.org/copyleft/gpl.html.
+ *
+ * Other Usage
+ * Alternatively, this file may be used in accordance with the terms
+ * and conditions contained in a signed written agreement between
+ * you and ecsec GmbH.
+ *
+ ***************************************************************************/
+
+package org.openecard.android.ex;
+
+
+/**
+ * Is thrown if apdu extended length is not supported by the corresponding smartphone device.
+ *
+ * @author Mike Prechtl
+ * @see <a href="https://www.openecard.org/en/ecard-api-framework/extended-length-problem">Extended-length-problem</a>
+ */
+public class NFCTagNotSupported extends Exception {
+
+	public NFCTagNotSupported(String message) {
+	super(message);
+    }
+
+	public NFCTagNotSupported(String message, Throwable cause) {
+	super(message, cause);
+    }
+
+}

--- a/clients/android-lib/src/main/java/org/openecard/android/utils/NfcUtils.java
+++ b/clients/android-lib/src/main/java/org/openecard/android/utils/NfcUtils.java
@@ -36,6 +36,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import org.openecard.android.ex.ApduExtLengthNotSupported;
+import org.openecard.android.ex.NFCTagNotSupported;
 import org.openecard.scio.NFCFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -89,16 +90,21 @@ public class NfcUtils {
 	}
     }
 
-    public void retrievedNFCTag(Intent intent) throws ApduExtLengthNotSupported {
+	public void retrievedNFCTag(Intent intent) throws ApduExtLengthNotSupported, NFCTagNotSupported {
 	// indicates that a nfc tag is there
 	Tag tagFromIntent = intent.getParcelableExtra(NfcAdapter.EXTRA_TAG);
-	if (tagFromIntent != null) {
-	    if (IsoDep.get(tagFromIntent).isExtendedLengthApduSupported()) {
-		// set nfc tag with timeout of five seconds
-		NFCFactory.setNFCTag(tagFromIntent, 5000);
-	    } else {
-		throw new ApduExtLengthNotSupported("APDU Extended Length is not supported.");
-	    }
+		if (tagFromIntent != null) {
+			IsoDep isoDep = IsoDep.get(tagFromIntent);
+			if (isoDep != null) {
+				if (isoDep.isExtendedLengthApduSupported()) {
+					// set nfc tag with timeout of five seconds
+					NFCFactory.setNFCTag(tagFromIntent, 5000);
+				} else {
+					throw new ApduExtLengthNotSupported("APDU Extended Length is not supported.");
+				}
+			} else {
+				throw new NFCTagNotSupported("The NFC chip is not supported");
+			}
 	}
     }
 


### PR DESCRIPTION
This prevents a nullptr if a non IsoDep card is presented to the device