### PR TITLE
Implement bugfix for JNA tmp files

### DIFF
--- a/clients/richclient/src/main/java/org/openecard/richclient/JnaRuntimeDirectoryFix.java
+++ b/clients/richclient/src/main/java/org/openecard/richclient/JnaRuntimeDirectoryFix.java
@@ -22,8 +22,11 @@
 
 package org.openecard.richclient;
 
+import java.io.File;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,48 +65,91 @@ public class JnaRuntimeDirectoryFix {
 
 	// if the property has been set externally don't change it
 	if (propJnaTmpDir != null) {
+	    LOG.info("Use {} from jna.tmpdir as tmp directory for JNA");
 	    return;
 	}
 
 	//check if we are on Linux
 	String osName = properties.getProperty("os.name");
 	if (osName.contains("nix") || osName.contains("nux") || osName.contains("aix")) {
-
-	    // we are on linux, first read "XDG_RUNTIME_DIR" to see if a user run dir is set
-	    String userRuntimeDir = System.getenv("XDG_RUNTIME_DIR");
-	    boolean canUseNormalTempDir = true;
-	    // if it is not set, we cannot use it
-	    boolean canUseUserRunDir = (userRuntimeDir != null);
-
-	    // then parse "/proc/mounts"
+	    // parse "/proc/mounts"
 	    List<MountInfo> mountInfos = MountInfo.getMounts();
-	    for (MountInfo mountInfo : mountInfos) {
-		String mountPath = mountInfo.getMountPath();
 
-		if (mountPath.equals("/tmp")) {
-		    // we can only use /tmp if "noexec" flag is not set in the mountOptions
-		    canUseNormalTempDir = !mountInfo.checkIfFlagIsSet(NOEXEC_FLAG);
-		} else if (mountPath.equals(userRuntimeDir)) {
-		    // same for the user run dir; if the user run dir is not set, then the equals above will be false
-		    canUseUserRunDir = !mountInfo.checkIfFlagIsSet(NOEXEC_FLAG);
-		}
+	    // convert mountInfos to mapping from mount path to MountInfo to speed up lookup of mount paths
+	    Map<String, MountInfo> map = new HashMap<>();
+	    for (MountInfo mountInfo : mountInfos) {
+		map.put(mountInfo.getMountPath(), mountInfo);
 	    }
 
-	    if (canUseNormalTempDir) {
-		// we can use /tmp directly and as JNA uses it as default anyway, nothing more to do here
+	    // get tmp directory
+	    String tmpDirPath = properties.getProperty("java.io.tmpdir");
+	    // get canonical file for tmp directory, as it might be a symlink
+	    File tmpDirectory = new File(tmpDirPath).getCanonicalFile();
+	    // check if noexec flag is set for tmp directory
+	    boolean noexecSetForTmp = checkIfNoexecFlagIsSetForLongestMatchingMountPath(map, tmpDirectory);
+
+	    if (!noexecSetForTmp) {
+		// we can use tmp directly and as JNA uses it as default anyway, nothing more to do here
+		LOG.info("Use default {} as tmp directory for JNA", tmpDirPath);
 		return;
 	    }
 
-	    if (canUseUserRunDir) {
-		// the user run dir is set and executable, set jna.tempdir to XDG_RUNTIME_DIR
-		LOG.debug("setting jna.tmpdir to user run dir at {}", userRuntimeDir);
-		System.getProperties().putIfAbsent(JNA_TMP_DIR, userRuntimeDir);
-	    } else {
-		// user run dir is not set or noexec as well, use '~/.openecard/run' as last ressort
-		LOG.debug("setting jna.tmpdir to be '~/.openecard/run' as last ressort");
-		System.getProperties().putIfAbsent(JNA_TMP_DIR, "~/.openecard/run");
+	    // we cannot use tmp directly, check the user run dir next
+	    // first read "XDG_RUNTIME_DIR" to see if a user run dir is set
+	    String userRuntimeDirPath = System.getenv("XDG_RUNTIME_DIR");
+
+	    // if it is set, then check for "noexec" flag like with tmp before
+	    boolean userRunDirSet = (userRuntimeDirPath != null);
+	    if (userRunDirSet) {
+		// get canonical file for user run time directory, as it might be a symlink
+		File userRuntimeDirectory = new File(userRuntimeDirPath).getCanonicalFile();
+		boolean noexecSetForUserRuntimeDir = checkIfNoexecFlagIsSetForLongestMatchingMountPath(map, userRuntimeDirectory);
+
+		if (!noexecSetForUserRuntimeDir) {
+		    // the user run dir is set and executable, set jna.tempdir to XDG_RUNTIME_DIR
+		    LOG.info("Setting jna.tmpdir to user run dir at {}", userRuntimeDirPath);
+		    System.getProperties().put(JNA_TMP_DIR, userRuntimeDirPath);
+		    return;
+		}
 	    }
+	    // neither tmp nor user run dir are usable,  use '~/.openecard/run' as last ressort
+	    LOG.info("Setting jna.tmpdir to be '~/.openecard/run' as last ressort");
+	    String homeDir = properties.getProperty("user.home");
+	    String openEcardRunDirectory = homeDir + "/.openecard/run";
+	    System.getProperties().put(JNA_TMP_DIR, openEcardRunDirectory);
 	}
+    }
+
+    /**
+     * Checks if for the provided File the longest matching mount path in the provided Map has the "noexec" flag set
+     *
+     * @param map a mapping from mount paths to their corresponding {@link MountInfo}
+     * @param file the {@link File} to check
+     * @return true, if the "noexec" flag for the provided File is set; false, if the "noexec" flag is not set or if the
+     * file does not have a matching mount path in the Mapping
+     * @throws IOException if an I/O error occurs during the construction of the canonical pathname
+     */
+    private static boolean checkIfNoexecFlagIsSetForLongestMatchingMountPath(Map<String, MountInfo> map, File file)
+	    throws IOException {
+
+	// Default case: if the provided dir is not in /proc/mounts, then the "noexec" flag is not set
+	boolean noexecFlagSet = false;
+
+	// find the closest parent to the directory and 
+	// see if it is in /proc/mounts and if so, if it has the "noexec" flag
+	while (file != null) {
+	    String path = file.getCanonicalPath();
+	    if (map.containsKey(path)) {
+		// we found the longest matching mount path
+		MountInfo mountInfo = map.get(path);
+		// check if "noexec" flag is set in the mountOptions
+		noexecFlagSet = mountInfo.checkIfFlagIsSet(NOEXEC_FLAG);
+		break;
+	    }
+	    // continue with parent of current file
+	    file = file.getParentFile();
+	}
+	return noexecFlagSet;
     }
 
 }

--- a/clients/richclient/src/main/java/org/openecard/richclient/JnaRuntimeDirectoryFix.java
+++ b/clients/richclient/src/main/java/org/openecard/richclient/JnaRuntimeDirectoryFix.java
@@ -22,9 +22,8 @@
 
 package org.openecard.richclient;
 
-import java.io.BufferedReader;
-import java.io.FileReader;
 import java.io.IOException;
+import java.util.List;
 import java.util.Properties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,6 +37,8 @@ import org.slf4j.LoggerFactory;
 public class JnaRuntimeDirectoryFix {
 
     private static final Logger LOG = LoggerFactory.getLogger(JnaRuntimeDirectoryFix.class);
+    private static final String NOEXEC_FLAG = "noexec";
+    private static final String JNA_TMP_DIR = "jna.tmpdir";
 
     /**
      * Sets the runtime directory for JNA to an executable directory
@@ -45,20 +46,19 @@ public class JnaRuntimeDirectoryFix {
      * The directory will be set to one of the following, in descending order of priority:
      * <ul>
      * <li>the directory pointed to by the System property <em>jna.tmpdir</em>, if this value is set</li>
-     * <li>the <em>/tmp</em> directory, if it is not mounted as 'noexec'. This is also the
-     * default for JNA.</li>
+     * <li>the <em>/tmp</em> directory, if it is not mounted as 'noexec'. This is also the default for JNA.</li>
      * <li>the directory pointed to by the enviroment variable <em>XDG_RUNTIME_DIR</em>, if this value is set and the
      * referenced directory is not mounted as 'noexec'.</li>
      * <li><em>~/.openecard/run</em> as a fallback if none of the above work
      * </ul>
      *
-     * @throws IOException if there is an error reading the "/proc/mounts" file, which contains information about 
+     * @throws IOException if there is an error reading the "/proc/mounts" file, which contains information about
      * whether a path is mounted as 'noexec' or not
      */
     public static void setJnaRuntimeDirectory() throws IOException {
 	// read value of jna.tmpdir property
 	Properties properties = new Properties(System.getProperties());
-	String propJnaTmpDir = properties.getProperty("jna.tmpdir");
+	String propJnaTmpDir = properties.getProperty(JNA_TMP_DIR);
 
 	// if the property has been set externally don't change it
 	if (propJnaTmpDir != null) {
@@ -75,23 +75,17 @@ public class JnaRuntimeDirectoryFix {
 	    // if it is not set, we cannot use it
 	    boolean canUseUserRunDir = (userRuntimeDir != null);
 
-	    // then read "/proc/mounts"
-	    try (BufferedReader bufferedReader = new BufferedReader(new FileReader("/proc/mounts"))) {
-		String line;
+	    // then parse "/proc/mounts"
+	    List<MountInfo> mountInfos = MountInfo.getMounts();
+	    for (MountInfo mountInfo : mountInfos) {
+		String mountPath = mountInfo.getMountPath();
 
-		while ((line = bufferedReader.readLine()) != null) {
-		    // split by whitespace to get the 6 parts individually
-		    String[] parts = line.split(" ");
-		    String mountPath = parts[1]; // get the path where the file system is mounted
-		    String mountOptions = parts[3]; // get the mount options
-
-		    if (mountPath.equals("/tmp")) {
-			// we can only use /tmp if the mountOptions do not contain "noexec"
-			canUseNormalTempDir = (!mountOptions.contains("noexec"));
-		    } else if (mountPath.equals(userRuntimeDir)) {
-			// same for the user run dir; if the user run dir is not set, then the equals above will be false
-			canUseUserRunDir = (!mountOptions.contains("noexec"));
-		    }
+		if (mountPath.equals("/tmp")) {
+		    // we can only use /tmp if "noexec" flag is not set in the mountOptions
+		    canUseNormalTempDir = !mountInfo.checkIfFlagIsSet(NOEXEC_FLAG);
+		} else if (mountPath.equals(userRuntimeDir)) {
+		    // same for the user run dir; if the user run dir is not set, then the equals above will be false
+		    canUseUserRunDir = !mountInfo.checkIfFlagIsSet(NOEXEC_FLAG);
 		}
 	    }
 
@@ -103,11 +97,11 @@ public class JnaRuntimeDirectoryFix {
 	    if (canUseUserRunDir) {
 		// the user run dir is set and executable, set jna.tempdir to XDG_RUNTIME_DIR
 		LOG.debug("setting jna.tmpdir to user run dir at {}", userRuntimeDir);
-		System.getProperties().putIfAbsent("jna.tmpdir", userRuntimeDir);
+		System.getProperties().putIfAbsent(JNA_TMP_DIR, userRuntimeDir);
 	    } else {
 		// user run dir is not set or noexec as well, use '~/.openecard/run' as last ressort
 		LOG.debug("setting jna.tmpdir to be '~/.openecard/run' as last ressort");
-		System.getProperties().putIfAbsent("jna.tmpdir", "~/.openecard/run");
+		System.getProperties().putIfAbsent(JNA_TMP_DIR, "~/.openecard/run");
 	    }
 	}
     }

--- a/clients/richclient/src/main/java/org/openecard/richclient/JnaRuntimeDirectoryFix.java
+++ b/clients/richclient/src/main/java/org/openecard/richclient/JnaRuntimeDirectoryFix.java
@@ -1,0 +1,115 @@
+/****************************************************************************
+ * Copyright (C) 2012-2019 ecsec GmbH.
+ * All rights reserved.
+ * Contact: ecsec GmbH (info@ecsec.de)
+ *
+ * This file is part of the Open eCard App.
+ *
+ * GNU General Public License Usage
+ * This file may be used under the terms of the GNU General Public
+ * License version 3.0 as published by the Free Software Foundation
+ * and appearing in the file LICENSE.GPL included in the packaging of
+ * this file. Please review the following information to ensure the
+ * GNU General Public License version 3.0 requirements will be met:
+ * http://www.gnu.org/copyleft/gpl.html.
+ *
+ * Other Usage
+ * Alternatively, this file may be used in accordance with the terms
+ * and conditions contained in a signed written agreement between
+ * you and ecsec GmbH.
+ *
+ ***************************************************************************/
+
+package org.openecard.richclient;
+
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.Properties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class represents a fix that sets the JNA runtime directory to an executable directory, because the default value
+ * /tmp may be mounted as 'noexec' on some systems, which will prevent the startup of the app.
+ *
+ * @author Sebastian Schuberth
+ */
+public class JnaRuntimeDirectoryFix {
+
+    private static final Logger LOG = LoggerFactory.getLogger(JnaRuntimeDirectoryFix.class);
+
+    /**
+     * Sets the runtime directory for JNA to an executable directory
+     * <p>
+     * The directory will be set to one of the following, in descending order of priority:
+     * <ul>
+     * <li>the directory pointed to by the System property <em>jna.tmpdir</em>, if this value is set</li>
+     * <li>the <em>/tmp</em> directory, if it is not mounted as 'noexec'. This is also the
+     * default for JNA.</li>
+     * <li>the directory pointed to by the enviroment variable <em>XDG_RUNTIME_DIR</em>, if this value is set and the
+     * referenced directory is not mounted as 'noexec'.</li>
+     * <li><em>~/.openecard/run</em> as a fallback if none of the above work
+     * </ul>
+     *
+     * @throws IOException if there is an error reading the "/proc/mounts" file, which contains information about 
+     * whether a path is mounted as 'noexec' or not
+     */
+    public static void setJnaRuntimeDirectory() throws IOException {
+	// read value of jna.tmpdir property
+	Properties properties = new Properties(System.getProperties());
+	String propJnaTmpDir = properties.getProperty("jna.tmpdir");
+
+	// if the property has been set externally don't change it
+	if (propJnaTmpDir != null) {
+	    return;
+	}
+
+	//check if we are on Linux
+	String osName = properties.getProperty("os.name");
+	if (osName.contains("nix") || osName.contains("nux") || osName.contains("aix")) {
+
+	    // we are on linux, first read "XDG_RUNTIME_DIR" to see if a user run dir is set
+	    String userRuntimeDir = System.getenv("XDG_RUNTIME_DIR");
+	    boolean canUseNormalTempDir = true;
+	    // if it is not set, we cannot use it
+	    boolean canUseUserRunDir = (userRuntimeDir != null);
+
+	    // then read "/proc/mounts"
+	    try (BufferedReader bufferedReader = new BufferedReader(new FileReader("/proc/mounts"))) {
+		String line;
+
+		while ((line = bufferedReader.readLine()) != null) {
+		    // split by whitespace to get the 6 parts individually
+		    String[] parts = line.split(" ");
+		    String mountPath = parts[1]; // get the path where the file system is mounted
+		    String mountOptions = parts[3]; // get the mount options
+
+		    if (mountPath.equals("/tmp")) {
+			// we can only use /tmp if the mountOptions do not contain "noexec"
+			canUseNormalTempDir = (!mountOptions.contains("noexec"));
+		    } else if (mountPath.equals(userRuntimeDir)) {
+			// same for the user run dir; if the user run dir is not set, then the equals above will be false
+			canUseUserRunDir = (!mountOptions.contains("noexec"));
+		    }
+		}
+	    }
+
+	    if (canUseNormalTempDir) {
+		// we can use /tmp directly and as JNA uses it as default anyway, nothing more to do here
+		return;
+	    }
+
+	    if (canUseUserRunDir) {
+		// the user run dir is set and executable, set jna.tempdir to XDG_RUNTIME_DIR
+		LOG.debug("setting jna.tmpdir to user run dir at {}", userRuntimeDir);
+		System.getProperties().putIfAbsent("jna.tmpdir", userRuntimeDir);
+	    } else {
+		// user run dir is not set or noexec as well, use '~/.openecard/run' as last ressort
+		LOG.debug("setting jna.tmpdir to be '~/.openecard/run' as last ressort");
+		System.getProperties().putIfAbsent("jna.tmpdir", "~/.openecard/run");
+	    }
+	}
+    }
+
+}

--- a/clients/richclient/src/main/java/org/openecard/richclient/MountInfo.java
+++ b/clients/richclient/src/main/java/org/openecard/richclient/MountInfo.java
@@ -22,16 +22,10 @@
 
 package org.openecard.richclient;
 
-import java.io.BufferedReader;
-import java.io.FileReader;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 /**
- * This class parses the "/proc/mounts" file under UNIX systems to retrieve mount information
+ * This class represents mount information obtained from the "/proc/mounts" file under UNIX systems
  *
  * @author Sebastian Schuberth
  */
@@ -62,45 +56,11 @@ public class MountInfo {
      * @param fileSystem the file sytem
      * @param mountOptions the mount options as a mapping from option to value
      */
-    private MountInfo(String device, String mountPath, String fileSystem, Map<String, String> mountOptions) {
+    MountInfo(String device, String mountPath, String fileSystem, Map<String, String> mountOptions) {
 	this.device = device;
 	this.mountPath = mountPath;
 	this.fileSystem = fileSystem;
 	this.mountOptions = mountOptions;
-    }
-
-    /**
-     * Hold the parsed mount information in memory
-     */
-    private static List<MountInfo> parsedMountInfo;
-
-    /**
-     * Parses "/proc/mounts" and returns the mount information in a list.
-     *
-     * @return the parsed mount information as a {@code List} of {@link MountInfo MountInfos}
-     * @throws IOException if there is an error reading the "/proc/mounts" file
-     */
-    public static List<MountInfo> getMounts() throws IOException {
-	// lazy load the mount information
-	if (parsedMountInfo == null) {
-	    parsedMountInfo = new ArrayList<>();
-	    try (BufferedReader bufferedReader = new BufferedReader(new FileReader("/proc/mounts"))) {
-		String line;
-
-		while ((line = bufferedReader.readLine()) != null) {
-		    // split by whitespace to get the 6 parts individually
-		    String[] parts = line.split(" ");
-		    String device = parts[0];
-		    String mountPath = parts[1];
-		    String fileSystem = parts[2];
-		    String mountOptions = parts[3];
-		    Map<String, String> parsedMountOptions = parseOptions(mountOptions);
-		    MountInfo mountInfo = new MountInfo(device, mountPath, fileSystem, parsedMountOptions);
-		    parsedMountInfo.add(mountInfo);
-		}
-	    }
-	}
-	return parsedMountInfo;
     }
 
     /**
@@ -147,36 +107,6 @@ public class MountInfo {
      */
     public boolean checkIfFlagIsSet(String flag) {
 	return mountOptions.containsKey(flag);
-    }
-
-    /**
-     * Parses the provided mount options in the form of "key=value,key=value,key,..."; for example "rw,mode=0664".
-     *
-     * @param mountOptions the mount options String to parse into a map
-     * @return Mapping between keys and values (with null values for value-less keys, e.g. "rw").
-     */
-    private static Map<String, String> parseOptions(String mountOptions) {
-	Map<String, String> optionsDict = new HashMap<>();
-	// split options by "," first
-	String[] options = mountOptions.split(",");
-	for (String option : options) {
-	    // then split each option into a key and a potential value
-	    String[] optionParts = option.split("=");
-	    switch (optionParts.length) {
-		case 0:
-		    // should not happen
-		    continue;
-		case 1:
-		    // only key like "rw" is present without value
-		    optionsDict.put(optionParts[0], null);
-		    break;
-		default:
-		    // we have a key=value pair
-		    optionsDict.put(optionParts[0], optionParts[1]);
-		    break;
-	    }
-	}
-	return optionsDict;
     }
 
 }

--- a/clients/richclient/src/main/java/org/openecard/richclient/MountInfo.java
+++ b/clients/richclient/src/main/java/org/openecard/richclient/MountInfo.java
@@ -1,0 +1,182 @@
+/****************************************************************************
+ * Copyright (C) 2012-2019 ecsec GmbH.
+ * All rights reserved.
+ * Contact: ecsec GmbH (info@ecsec.de)
+ *
+ * This file is part of the Open eCard App.
+ *
+ * GNU General Public License Usage
+ * This file may be used under the terms of the GNU General Public
+ * License version 3.0 as published by the Free Software Foundation
+ * and appearing in the file LICENSE.GPL included in the packaging of
+ * this file. Please review the following information to ensure the
+ * GNU General Public License version 3.0 requirements will be met:
+ * http://www.gnu.org/copyleft/gpl.html.
+ *
+ * Other Usage
+ * Alternatively, this file may be used in accordance with the terms
+ * and conditions contained in a signed written agreement between
+ * you and ecsec GmbH.
+ *
+ ***************************************************************************/
+
+package org.openecard.richclient;
+
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This class parses the "/proc/mounts" file under UNIX systems to retrieve mount information
+ *
+ * @author Sebastian Schuberth
+ */
+public class MountInfo {
+
+    /**
+     * The mounted device (can be "none" or any arbitrary string for virtual file systems).
+     */
+    private final String device;
+    /**
+     * The path where the file system is mounted.
+     */
+    private final String mountPath;
+    /**
+     * The file system.
+     */
+    private final String fileSystem;
+    /**
+     * The mount options.
+     */
+    private final Map<String, String> mountOptions;
+
+    /**
+     * The constructor to create a new {@code MountInfo} object
+     *
+     * @param device the mounted device
+     * @param mountPath the path where the file system is mounted
+     * @param fileSystem the file sytem
+     * @param mountOptions the mount options as a mapping from option to value
+     */
+    private MountInfo(String device, String mountPath, String fileSystem, Map<String, String> mountOptions) {
+	this.device = device;
+	this.mountPath = mountPath;
+	this.fileSystem = fileSystem;
+	this.mountOptions = mountOptions;
+    }
+
+    /**
+     * Hold the parsed mount information in memory
+     */
+    private static List<MountInfo> parsedMountInfo;
+
+    /**
+     * Parses "/proc/mounts" and returns the mount information in a list.
+     *
+     * @return the parsed mount information as a {@code List} of {@link MountInfo MountInfos}
+     * @throws IOException if there is an error reading the "/proc/mounts" file
+     */
+    public static List<MountInfo> getMounts() throws IOException {
+	// lazy load the mount information
+	if (parsedMountInfo == null) {
+	    parsedMountInfo = new ArrayList<>();
+	    try (BufferedReader bufferedReader = new BufferedReader(new FileReader("/proc/mounts"))) {
+		String line;
+
+		while ((line = bufferedReader.readLine()) != null) {
+		    // split by whitespace to get the 6 parts individually
+		    String[] parts = line.split(" ");
+		    String device = parts[0];
+		    String mountPath = parts[1];
+		    String fileSystem = parts[2];
+		    String mountOptions = parts[3];
+		    Map<String, String> parsedMountOptions = parseOptions(mountOptions);
+		    MountInfo mountInfo = new MountInfo(device, mountPath, fileSystem, parsedMountOptions);
+		    parsedMountInfo.add(mountInfo);
+		}
+	    }
+	}
+	return parsedMountInfo;
+    }
+
+    /**
+     * Returns the mounted device
+     *
+     * @return the mounted device
+     */
+    public String getDevice() {
+	return device;
+    }
+
+    /**
+     * Returns the mount path
+     *
+     * @return the mount path
+     */
+    public String getMountPath() {
+	return mountPath;
+    }
+
+    /**
+     * Returns the file system
+     *
+     * @return the file system
+     */
+    public String getFileSystem() {
+	return fileSystem;
+    }
+
+    /**
+     * Returns the mount options as a {@code Map}
+     *
+     * @return the mount options
+     */
+    public Map<String, String> getMountOptions() {
+	return mountOptions;
+    }
+
+    /**
+     * Checks if the provided flag is set in the mount options
+     *
+     * @param flag the flag to check
+     * @return true, if the flag is set; false otherwise
+     */
+    public boolean checkIfFlagIsSet(String flag) {
+	return mountOptions.containsKey(flag);
+    }
+
+    /**
+     * Parses the provided mount options in the form of "key=value,key=value,key,..."; for example "rw,mode=0664".
+     *
+     * @param mountOptions the mount options String to parse into a map
+     * @return Mapping between keys and values (with null values for value-less keys, e.g. "rw").
+     */
+    private static Map<String, String> parseOptions(String mountOptions) {
+	Map<String, String> optionsDict = new HashMap<>();
+	// split options by "," first
+	String[] options = mountOptions.split(",");
+	for (String option : options) {
+	    // then split each option into a key and a potential value
+	    String[] optionParts = option.split("=");
+	    switch (optionParts.length) {
+		case 0:
+		    // should not happen
+		    continue;
+		case 1:
+		    // only key like "rw" is present without value
+		    optionsDict.put(optionParts[0], null);
+		    break;
+		default:
+		    // we have a key=value pair
+		    optionsDict.put(optionParts[0], optionParts[1]);
+		    break;
+	    }
+	}
+	return optionsDict;
+    }
+
+}

--- a/clients/richclient/src/main/java/org/openecard/richclient/Mounts.java
+++ b/clients/richclient/src/main/java/org/openecard/richclient/Mounts.java
@@ -1,0 +1,194 @@
+/****************************************************************************
+ * Copyright (C) 2012-2019 ecsec GmbH.
+ * All rights reserved.
+ * Contact: ecsec GmbH (info@ecsec.de)
+ *
+ * This file is part of the Open eCard App.
+ *
+ * GNU General Public License Usage
+ * This file may be used under the terms of the GNU General Public
+ * License version 3.0 as published by the Free Software Foundation
+ * and appearing in the file LICENSE.GPL included in the packaging of
+ * this file. Please review the following information to ensure the
+ * GNU General Public License version 3.0 requirements will be met:
+ * http://www.gnu.org/copyleft/gpl.html.
+ *
+ * Other Usage
+ * Alternatively, this file may be used in accordance with the terms
+ * and conditions contained in a signed written agreement between
+ * you and ecsec GmbH.
+ *
+ ***************************************************************************/
+
+package org.openecard.richclient;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+/**
+ * This class parses the "/proc/mounts" file under UNIX systems to retrieve mount information in from of
+ * {@link MountInfo} objects
+ *
+ * @author Sebastian Schuberth
+ */
+public class Mounts {
+
+    /**
+     * Hold the parsed mount information in memory
+     */
+    private final List<MountInfo> parsedMountInfo;
+
+    /**
+     * Mapping from mount path to MountInfo to speed up lookup of mount paths
+     */
+    private final Map<String, MountInfo> map;
+
+    private static Mounts instance = null;
+
+    /**
+     * Private constructor to create a {@code Mounts} instance
+     *
+     * @param parsedMountInfo a {@code List} of {@link MountInfo} parsed from /proc/mounts
+     * @param map a mapping from mount paths to {@link MountInfo} to speed up lookup of mount paths
+     */
+    private Mounts(List<MountInfo> parsedMountInfo, Map<String, MountInfo> map) {
+	this.parsedMountInfo = parsedMountInfo;
+	this.map = map;
+    }
+
+    /**
+     * Parses "/proc/mounts" and returns a {@code Mounts} object that contains a List of all {@link MountInfo}
+     *
+     * @return the parsed mount information as a {@code List} of {@link MountInfo MountInfos} within a {@code Mounts}
+     * object
+     * @throws IOException if there is an error reading the "/proc/mounts" file
+     */
+    public static Mounts readMounts() throws IOException {
+	// lazy load the mount information
+	if (instance == null) {
+	    List<MountInfo> parsedMountInfo = new ArrayList<>();
+	    try (BufferedReader bufferedReader = new BufferedReader(new FileReader("/proc/mounts"))) {
+		String line;
+		
+		while ((line = bufferedReader.readLine()) != null) {
+		    // split by whitespace to get the 6 parts individually
+		    String[] parts = line.split(" ");
+		    String device = parts[0];
+		    String mountPath = parts[1];
+		    String fileSystem = parts[2];
+		    String mountOptions = parts[3];
+		    Map<String, String> parsedMountOptions = parseOptions(mountOptions);
+		    MountInfo mountInfo = new MountInfo(device, mountPath, fileSystem, parsedMountOptions);
+		    parsedMountInfo.add(mountInfo);
+		}
+	    }
+
+	    // convert mountInfos to mapping from mount path to MountInfo to speed up lookup of mount paths
+	    Map<String, MountInfo> map = new HashMap<>();
+	    for (MountInfo mountInfo : parsedMountInfo) {
+		map.put(mountInfo.getMountPath(), mountInfo);
+	    }
+	    instance = new Mounts(parsedMountInfo, map);
+	}
+	return instance;
+    }
+
+    /**
+     * Returns all parsed mount information in a list
+     *
+     * @return a {@code List} of all parsed {@link MountInfo MountInfos}
+     */
+    public List<MountInfo> getMountInfoList() {
+	return parsedMountInfo;
+    }
+
+    /**
+     * Returns a mapping from all mount paths to their respective {@code MountInfo}
+     *
+     * @return a mapping from all mount paths to their respective {@link MountInfo MountInfos}
+     */
+    public Map<String, MountInfo> getMountInfoMapping() {
+	return map;
+    }
+
+    /**
+     * Checks if for the provided file path the longest matching mount path has the "noexec" flag set
+     *
+     * @param filePath the path to check
+     * @return true, if the "noexec" flag for the provided file path is set; false, if the "noexec" flag is not set or
+     * if the file does not have a matching mount path in /proc/mounts (not even "/")
+     * @throws IOException if an I/O error occurs during the construction of the canonical pathname
+     * @throws NoSuchElementException if no matching mount path (not even "/") exists in /proc/mounts
+     */
+    public boolean hasNoExecFlag(String filePath) throws IOException, NoSuchElementException {
+	// get canonical file path, as the path might be a symlink
+	String canonicalFilePath = new File(filePath).getCanonicalPath();
+	// look up the mount point this path is in
+	MountInfo mountPoint = getMatchingMountPoint(canonicalFilePath);
+	// check if noexec flag is set for this mount point
+	return mountPoint.checkIfFlagIsSet("noexec");
+    }
+
+    /**
+     * Returns the longest matching mount point for the provided file path
+     *
+     * @param filePath the file path
+     * @return the longest matching {@link MountInfo} for the given path
+     * @throws IOException if an I/O error occurs during the construction of the canonical pathname
+     * @throws NoSuchElementException if no matching mount path (not even "/") exists in /proc/mounts
+     */
+    public MountInfo getMatchingMountPoint(String filePath) throws IOException, NoSuchElementException {
+	File file = new File(filePath);
+	// find the closest parent to the directory 
+	while (file != null) {
+	    String path = file.getCanonicalPath();
+	    if (map.containsKey(path)) {
+		// we found the longest matching mount path; this could be "/" at the very end
+		MountInfo mountInfo = map.get(path);
+		return mountInfo;
+	    }
+	    // continue with parent of current file
+	    file = file.getParentFile();
+	}
+	// we did not find a matching mount path (not even "/"), throw error
+	throw new NoSuchElementException("There is no matching mount point for path " + filePath);
+    }
+
+    /**
+     * Parses the provided mount options in the form of "key=value,key=value,key,..."; for example "rw,mode=0664".
+     *
+     * @param mountOptions the mount options String to parse into a map
+     * @return Mapping between keys and values (with null values for value-less keys, e.g. "rw").
+     */
+    private static Map<String, String> parseOptions(String mountOptions) {
+	Map<String, String> optionsDict = new HashMap<>();
+	// split options by "," first
+	String[] options = mountOptions.split(",");
+	for (String option : options) {
+	    // then split each option into a key and a potential value
+	    String[] optionParts = option.split("=");
+	    switch (optionParts.length) {
+		case 0:
+		    // should not happen
+		    continue;
+		case 1:
+		    // only key like "rw" is present without value
+		    optionsDict.put(optionParts[0], null);
+		    break;
+		default:
+		    // we have a key=value pair
+		    optionsDict.put(optionParts[0], optionParts[1]);
+		    break;
+	    }
+	}
+	return optionsDict;
+    }
+
+}

--- a/clients/richclient/src/main/java/org/openecard/richclient/RichClient.java
+++ b/clients/richclient/src/main/java/org/openecard/richclient/RichClient.java
@@ -32,15 +32,12 @@ import iso.std.iso_iec._24727.tech.schema.EstablishContextResponse;
 import iso.std.iso_iec._24727.tech.schema.Initialize;
 import iso.std.iso_iec._24727.tech.schema.ReleaseContext;
 import iso.std.iso_iec._24727.tech.schema.Terminate;
-import java.io.BufferedReader;
-import java.io.FileReader;
 import java.io.IOException;
 import java.net.BindException;
 import java.util.List;
 import java.net.Socket;
 import java.net.URL;
 import java.nio.charset.UnsupportedCharsetException;
-import java.util.Properties;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.FutureTask;
@@ -143,7 +140,7 @@ public final class RichClient {
 	// try to set the JNA runtime directory because the default value /tmp
 	// may be mounted as 'noexec' on some systems
 	try {
-	    setJnaRuntimeDiretory();
+	    JnaRuntimeDirectoryFix.setJnaRuntimeDirectory();
 	} catch (IOException ex) {
 	    System.err.println("Failed to setup runtime directory for JNA");
 	    ex.printStackTrace(System.err);
@@ -501,63 +498,6 @@ public final class RichClient {
 	    LOG.debug("Registry key {}\\{} does not exist or has wrong type.", key, value);
 	}
 	return defaultValue;
-    }
-
-    private static void setJnaRuntimeDiretory() throws IOException {
-	// read value of jna.tmpdir property
-	Properties properties = new Properties(System.getProperties());
-	String propJnaTmpDir = properties.getProperty("jna.tmpdir");
-
-	// if the property has been set externally don't change it
-	if (propJnaTmpDir != null) {
-	    return;
-	}
-
-	//check if we are on Linux
-	String osName = properties.getProperty("os.name");
-	if (osName.contains("nix") || osName.contains("nux") || osName.contains("aix")) {
-
-	    // we are on linux, first read "XDG_RUNTIME_DIR" to see if a user run dir is set
-	    String userRuntimeDir = System.getenv("XDG_RUNTIME_DIR");
-	    boolean canUseNormalTempDir = true;
-	    // if it is not set, we cannot use it
-	    boolean canUseUserRunDir = (userRuntimeDir != null);
-
-	    // then read "/proc/mounts"
-	    try (BufferedReader bufferedReader = new BufferedReader(new FileReader("/proc/mounts"))) {
-		String line;
-
-		while ((line = bufferedReader.readLine()) != null) {
-		    // split by whitespace to get the 6 parts individually
-		    String[] parts = line.split(" ");
-		    String mountPath = parts[1]; // get the path where the file system is mounted
-		    String mountOptions = parts[3]; // get the mount options
-
-		    if (mountPath.equals("/tmp")) {
-			// we can only use /tmp if the mountOptions do not contain "noexec"
-			canUseNormalTempDir = (!mountOptions.contains("noexec"));
-		    } else if (mountPath.equals(userRuntimeDir)) {
-			// same for the user run dir; if the user run dir is not set, then the equals above will be false
-			canUseUserRunDir = (!mountOptions.contains("noexec"));
-		    }
-		}
-	    }
-
-	    if (canUseNormalTempDir) {
-		// we can use /tmp directly and as JNA uses it as default anyway, nothing more to do here
-		return;
-	    }
-
-	    if (canUseUserRunDir) {
-		// the user run dir is set and executable, set jna.tempdir to XDG_RUNTIME_DIR
-		LOG.debug("setting jna.tmpdir to user run dir at {}", userRuntimeDir);
-		System.getProperties().putIfAbsent("jna.tmpdir", userRuntimeDir);
-	    } else {
-		// user run dir is not set or noexec as well, use '~/.openecard/run' as last ressort
-		LOG.debug("setting jna.tmpdir to be '~/.openecard/run' as last ressort");
-		System.getProperties().putIfAbsent("jna.tmpdir", "~/.openecard/run");
-	    }
-	}
     }
 
 }


### PR DESCRIPTION
This PR implements a bugfix for [issue 808](https://dev.openecard.org/issues/808). As such, it is now possible to run the Open eCard App on a linux system while having the default 'tmp' directory mounted with the 'noexec' flag. In this case, an alternative directory is used.