### PR TITLE
Update UI fix

### DIFF
--- a/clients/richclient/pom.xml
+++ b/clients/richclient/pom.xml
@@ -117,6 +117,10 @@
 
 		<dependency>
 			<groupId>org.openjfx</groupId>
+			<artifactId>javafx-swing</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.openjfx</groupId>
 			<artifactId>javafx-controls</artifactId>
 		</dependency>
 

--- a/clients/richclient/src/main/java/org/openecard/richclient/gui/Status.java
+++ b/clients/richclient/src/main/java/org/openecard/richclient/gui/Status.java
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (C) 2012-2016 ecsec GmbH.
+ * Copyright (C) 2012-2020 ecsec GmbH.
  * All rights reserved.
  * Contact: ecsec GmbH (info@ecsec.de)
  *
@@ -44,8 +44,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentSkipListMap;
-import javafx.application.Platform;
-import javafx.stage.Stage;
 import javax.annotation.Nullable;
 import javax.swing.BorderFactory;
 import javax.swing.Box;
@@ -455,22 +453,13 @@ public class Status implements EventCallback {
 
     private synchronized void openUpdateWindow(VersionUpdateChecker checker) {
 	if (uw == null) {
-	    // no window displayed, start it up	    
-
-	    Platform.runLater(() -> {
-		Stage stage = new Stage();
-		stage.setOnHidden(event -> {
-		    synchronized (this) {
-			uw = null;
-		    }
-		});
-		uw = new UpdateWindow(checker, stage);
-		uw.init();
-	    });
-	} else {
-	    // window is already displayed, just bring it to the front
-	    Platform.runLater(uw::toFront);
+	    // init update window
+	    UpdateWindow uwTmp = new UpdateWindow(checker);
+	    uwTmp.init();
+	    uw = uwTmp;
 	}
+
+	uw.showDialog();
     }
 
 }

--- a/clients/richclient/src/main/java/org/openecard/richclient/gui/update/UpdateWindow.java
+++ b/clients/richclient/src/main/java/org/openecard/richclient/gui/update/UpdateWindow.java
@@ -144,7 +144,7 @@ public class UpdateWindow {
 
 	if (majUpdate != null) {
 	    String version = majUpdate.getVersion().toString();
-	    String type = "major";
+	    String type = lang.translationForKey("major");
 	    String link = majUpdate.getDownloadLink().toString();
 	    Hyperlink hyperlink = generateHyperLink(link);
 
@@ -158,7 +158,7 @@ public class UpdateWindow {
 
 	if (minUpdate != null) {
 	    String version = minUpdate.getVersion().toString();
-	    String type = "minor";
+	    String type = lang.translationForKey("minor");
 	    String link = minUpdate.getDownloadLink().toString();
 	    Hyperlink hyperlink = generateHyperLink(link);
 
@@ -172,7 +172,7 @@ public class UpdateWindow {
 
 	if (secUpdate != null) {
 	    String version = secUpdate.getVersion().toString();
-	    String type = "security";
+	    String type = lang.translationForKey("patch");
 	    String link = secUpdate.getDownloadLink().toString();
 	    Hyperlink hyperlink = generateHyperLink(link);
 	    updateList.add(new VersionUpdateTableItem(version, type, hyperlink));

--- a/gui/swing/src/main/java/org/openecard/gui/swing/common/SwingUtils.java
+++ b/gui/swing/src/main/java/org/openecard/gui/swing/common/SwingUtils.java
@@ -46,7 +46,7 @@ public class SwingUtils {
 	    }
 
 	    boolean browserOpened = false;
-	    if (Desktop.isDesktopSupported()) {
+	    if (Desktop.isDesktopSupported() && !SysUtils.isUnix()) {
 		if ("file".equals(uri.getScheme()) && Desktop.getDesktop().isSupported(Desktop.Action.OPEN)) {
 		    try {
 			Desktop.getDesktop().open(new File(uri));

--- a/i18n/src/main/resources/openecard_i18n/update/Messages_C.properties
+++ b/i18n/src/main/resources/openecard_i18n/update/Messages_C.properties
@@ -6,3 +6,6 @@ update_type = Update Type
 direct_download = Direct download
 manual_download = Alternatively, you can manually download a new version here: 
 version_not_maintained = The current version %s is not maintained anymore. Please upgrade to a new version: 
+major = Major
+minor = Feature
+patch = Bugfix

--- a/packager/richclient-bundle/src/main/java/module-info.java
+++ b/packager/richclient-bundle/src/main/java/module-info.java
@@ -42,6 +42,7 @@ module org.openecard.richclient {
     requires javafx.base;
     requires javafx.controls;
     requires javafx.graphics;
+    requires javafx.swing;
 
     /* EC ciphers for JSSE */
     requires jdk.crypto.ec;

--- a/packager/richclient-bundle/src/main/java/module-info.java
+++ b/packager/richclient-bundle/src/main/java/module-info.java
@@ -69,6 +69,8 @@ module org.openecard.richclient {
     opens org.openecard.mdlw.sal.config to java.xml.bind;
     opens org.openecard.addon.manifest to java.xml.bind;
 
+    opens org.openecard.richclient.gui.update;
+
     opens jnasmartcardio to java.base;
 
 	/* JNA needs access to the jnidispatch lib on osx*/

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
 		<version.bouncycastle>1.62</version.bouncycastle>
 		<version.jmockit>1.47</version.jmockit>
 		<version.pmd>6.25.0</version.pmd>
-		<version.openjfx>12.0.2</version.openjfx>
+		<version.openjfx>14.0.2.1</version.openjfx>
 		<!-- preset argLine for Netbeans direct test execution -->
 		<argLine />
 


### PR DESCRIPTION
This fixes the update dialog which was not starting on my Java 14 based system. 

It should be checked on a few systems whether it displays correctly as the sizing code was not working at all and I had to find a different way to set the right size of the dialog. A check on a Windows and a Gnome System should suffice.

The update icon can be shown by setting the content of the VERSION file in common/src/main/resources/openecard/VERSION to an older version such as 1.4.1.