### PR TITLE
Complement documentation for iOS setup

### DIFF
--- a/doc/integration/project_setup.rst
+++ b/doc/integration/project_setup.rst
@@ -27,6 +27,8 @@ the app must include the following to be able to detect and communicate with ISO
 
 Examples can be found in the `reference implementation for ios <https://github.com/ecsec/open-ecard-ios>`_.
 
+In addition, the Info.plist file has to contain the <NFCReaderUsageDescription> key with a value properly explaining the need for the NFC usage. 
+
 The corresponding protocol definitions of the API described in this document can be found within the bundle in the "Headers" folder.
 
 Android

--- a/doc/integration/project_setup.rst
+++ b/doc/integration/project_setup.rst
@@ -25,8 +25,7 @@ the app must include the following to be able to detect and communicate with ISO
 
 The Near Field Communication Tag Reader Session Formats Entitlement:
 
-.. code-block:: XML
-   :substitutions:
+.. code-block:: xml
    
    <key>com.apple.developer.nfc.readersession.formats</key>
    <array>
@@ -36,20 +35,18 @@ The Near Field Communication Tag Reader Session Formats Entitlement:
 
 A list of supported application identifiers of ISO7816 tags within the Info.plist file:
 
-.. code-block:: XML
-   :substitutions:
+.. code-block:: xml
 
     <key>com.apple.developer.nfc.readersession.iso7816.select-identifiers</key>
     <array>
-        <!-- Electronic passports -->
+        <!-- ICAO ePassport compatible token such as the German eID -->
     	<string>A0000002471001</string>
     </array>
 
 
-The Info.plist must also contain the <NFCReaderUsageDescription> key with a value properly explaining the need for the NFC usage. 
+The Info.plist must also contain the ``<NFCReaderUsageDescription>`` key with a value properly explaining the need for the NFC usage. 
 
-.. code-block:: XML
-   :substitutions:
+.. code-block:: xml
 
     <key>NFCReaderUsageDescription</key>
     <string>Communication with NFC enabled eID cards for authentication processes</string>

--- a/doc/integration/project_setup.rst
+++ b/doc/integration/project_setup.rst
@@ -20,6 +20,13 @@ Within the Podfile the following has to be specified:
 
 Since the framework uses NFC technology, within "Capabilities and Signing" the "Near field communication" capability has to be activated.
 
+As described in the `Apple Developer documentation <https://developer.apple.com/documentation/corenfc/nfciso7816tag>`_
+the app must include the following to be able to detect and communicate with ISO7816 tags:
+ - The Near Field Communication Tag Reader Session Formats Entitlement
+ - A list of supported application identifiers 
+
+Examples can be found in the `reference implementation for ios <https://github.com/ecsec/open-ecard-ios>`_.
+
 The corresponding protocol definitions of the API described in this document can be found within the bundle in the "Headers" folder.
 
 Android

--- a/doc/integration/project_setup.rst
+++ b/doc/integration/project_setup.rst
@@ -22,12 +22,40 @@ Since the framework uses NFC technology, within "Capabilities and Signing" the "
 
 As described in the `Apple Developer documentation <https://developer.apple.com/documentation/corenfc/nfciso7816tag>`_
 the app must include the following to be able to detect and communicate with ISO7816 tags:
- - The Near Field Communication Tag Reader Session Formats Entitlement
- - A list of supported application identifiers 
 
-Examples can be found in the `reference implementation for ios <https://github.com/ecsec/open-ecard-ios>`_.
+The Near Field Communication Tag Reader Session Formats Entitlement:
 
-In addition, the Info.plist file has to contain the <NFCReaderUsageDescription> key with a value properly explaining the need for the NFC usage. 
+.. code-block:: XML
+   :substitutions:
+   
+   <key>com.apple.developer.nfc.readersession.formats</key>
+   <array>
+        <string>TAG</string>
+   </array>
+
+
+A list of supported application identifiers of ISO7816 tags within the Info.plist file:
+
+.. code-block:: XML
+   :substitutions:
+
+    <key>com.apple.developer.nfc.readersession.iso7816.select-identifiers</key>
+    <array>
+        <!-- Electronic passports -->
+    	<string>A0000002471001</string>
+    </array>
+
+
+The Info.plist must also contain the <NFCReaderUsageDescription> key with a value properly explaining the need for the NFC usage. 
+
+.. code-block:: XML
+   :substitutions:
+
+    <key>NFCReaderUsageDescription</key>
+    <string>Communication with NFC enabled eID cards for authentication processes</string>
+
+Find a full example at the `reference implementation for ios <https://github.com/ecsec/open-ecard-ios>`_.
+
 
 The corresponding protocol definitions of the API described in this document can be found within the bundle in the "Headers" folder.
 

--- a/doc/integration/project_setup.rst
+++ b/doc/integration/project_setup.rst
@@ -29,7 +29,7 @@ The Near Field Communication Tag Reader Session Formats Entitlement:
    
    <key>com.apple.developer.nfc.readersession.formats</key>
    <array>
-        <string>TAG</string>
+     <string>TAG</string>
    </array>
 
 
@@ -39,8 +39,8 @@ A list of supported application identifiers of ISO7816 tags within the Info.plis
 
     <key>com.apple.developer.nfc.readersession.iso7816.select-identifiers</key>
     <array>
-        <!-- ICAO ePassport compatible token such as the German eID -->
-    	<string>A0000002471001</string>
+      <!-- ICAO ePassport compatible token such as the German eID -->
+      <string>A0000002471001</string>
     </array>
 
 


### PR DESCRIPTION
Adds the entitlement and AID list necessaties to the docs.