### PR TITLE
Missing pin codes

### DIFF
--- a/addons/tr03112/src/main/java/org/openecard/sal/protocol/eac/gui/CHATStepAction.java
+++ b/addons/tr03112/src/main/java/org/openecard/sal/protocol/eac/gui/CHATStepAction.java
@@ -22,6 +22,7 @@
 
 package org.openecard.sal.protocol.eac.gui;
 
+import org.openecard.common.ifd.PacePinStatus;
 import iso.std.iso_iec._24727.tech.schema.ConnectionHandleType;
 import java.util.ArrayList;
 import java.util.List;
@@ -128,7 +129,7 @@ public class CHATStepAction extends StepAction {
 	    if (! SysUtils.isMobileDevice()) {
 		cardHandle = ph.connectCardIfNeeded();
 		if (passwordType == PasswordID.PIN) {
-		    EacPinStatus pinState = ph.getPinStatus();
+		    PacePinStatus pinState = ph.getPinStatus();
 		    status.update(pinState);
 		}
 		nativePace = ph.isNativePinEntry();
@@ -137,7 +138,7 @@ public class CHATStepAction extends StepAction {
 		paceMarker = ph.getPaceMarker(passwordType.getString());
 	    } else {
 		// mobile device, pick only available reader and proceed
-		status.update(EacPinStatus.UNKNOWN);
+		status.update(PacePinStatus.UNKNOWN);
 		cardHandle = ph.getMobileReader();
 		nativePace = false;
 		paceMarker = ph.getPaceMarker(passwordType.getString());

--- a/addons/tr03112/src/main/java/org/openecard/sal/protocol/eac/gui/PINStep.java
+++ b/addons/tr03112/src/main/java/org/openecard/sal/protocol/eac/gui/PINStep.java
@@ -22,6 +22,7 @@
 
 package org.openecard.sal.protocol.eac.gui;
 
+import org.openecard.common.ifd.PacePinStatus;
 import java.util.List;
 import org.openecard.binding.tctoken.TR03112Keys;
 import org.openecard.common.DynamicContext;
@@ -101,7 +102,7 @@ public final class PINStep extends Step {
 	updateAttemptsDisplay();
     }
 
-    public void setStatus(EacPinStatus status) {
+    public void setStatus(PacePinStatus status) {
 	this.status.update(status);
 	updateAttemptsDisplay();
 	updateCanData();

--- a/addons/tr03112/src/main/java/org/openecard/sal/protocol/eac/gui/PINStepAction.java
+++ b/addons/tr03112/src/main/java/org/openecard/sal/protocol/eac/gui/PINStepAction.java
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (C) 2012-2019 ecsec GmbH.
+ * Copyright (C) 2012-2020 ecsec GmbH.
  * All rights reserved.
  * Contact: ecsec GmbH (info@ecsec.de)
  *
@@ -21,6 +21,7 @@
  ***************************************************************************/
 package org.openecard.sal.protocol.eac.gui;
 
+import org.openecard.common.ifd.PacePinStatus;
 import iso.std.iso_iec._24727.tech.schema.ConnectionHandleType;
 import iso.std.iso_iec._24727.tech.schema.EstablishChannelResponse;
 import java.util.Map;
@@ -84,7 +85,7 @@ public class PINStepAction extends AbstractPasswordStepAction {
 	    conHandle = ph.connectCardIfNeeded();
 	    this.ctx.put(TR03112Keys.CONNECTION_HANDLE, conHandle);
 
-	    EacPinStatus currentState;
+	    PacePinStatus currentState;
 	    currentState = ph.getPinStatus();
 
 	    pinState.update(currentState);
@@ -110,14 +111,14 @@ public class PINStepAction extends AbstractPasswordStepAction {
 		EstablishChannelResponse response = performPACEWithCAN(oldResults, conHandle);
 		if (response == null) {
 		    LOG.debug("The CAN does not meet the format requirements.");
-		    step.setStatus(EacPinStatus.RC1);
+		    step.setStatus(PacePinStatus.RC1);
 		    return new StepActionResult(StepActionResultStatus.REPEAT);
 		}
 
 		if (response.getResult().getResultMajor().equals(ECardConstants.Major.ERROR)) {
 		    if (response.getResult().getResultMinor().equals(ECardConstants.Minor.IFD.AUTHENTICATION_FAILED)) {
 			LOG.error("Failed to authenticate with the given CAN.");
-			step.setStatus(EacPinStatus.RC1);
+			step.setStatus(PacePinStatus.RC1);
 			return new StepActionResult(StepActionResultStatus.REPEAT);
 		    } else {
 			WSHelper.checkResult(response);
@@ -153,18 +154,18 @@ public class PINStepAction extends AbstractPasswordStepAction {
 		if (establishChannelResponse.getResult().getResultMinor().equals(ECardConstants.Minor.IFD.PASSWORD_ERROR)) {
 		    // update step display
 		    LOG.info("Wrong PIN entered, trying again (try number {}).", retryCounter);
-		    this.step.setStatus(EacPinStatus.RC2);
+		    this.step.setStatus(PacePinStatus.RC2);
 		    // repeat the step
 		    return new StepActionResult(StepActionResultStatus.REPEAT);
 		} else if (establishChannelResponse.getResult().getResultMinor().equals(ECardConstants.Minor.IFD.PASSWORD_SUSPENDED)) {
 		    // update step display
-		    step.setStatus(EacPinStatus.RC1);
+		    step.setStatus(PacePinStatus.RC1);
 		    LOG.info("Wrong PIN entered, trying again (try number {}).", retryCounter);
 		    // repeat the step
 		    return new StepActionResult(StepActionResultStatus.REPEAT);
 		} else if (establishChannelResponse.getResult().getResultMinor().equals(ECardConstants.Minor.IFD.PASSWORD_BLOCKED)) {
 		    LOG.warn("Wrong PIN entered. The PIN is blocked.");
-		    pinState.update(EacPinStatus.BLOCKED);
+		    pinState.update(PacePinStatus.BLOCKED);
 		    return new StepActionResult(StepActionResultStatus.REPEAT,
 			    new ErrorStep(lang.translationForKey("step_error_title_blocked", pin),
 				    lang.translationForKey("step_error_pin_blocked", pin, pin, puk, pin),

--- a/addons/tr03112/src/main/java/org/openecard/sal/protocol/eac/gui/PaceCardHelper.java
+++ b/addons/tr03112/src/main/java/org/openecard/sal/protocol/eac/gui/PaceCardHelper.java
@@ -10,6 +10,7 @@
 
 package org.openecard.sal.protocol.eac.gui;
 
+import org.openecard.common.ifd.PacePinStatus;
 import iso.std.iso_iec._24727.tech.schema.CardApplicationConnect;
 import iso.std.iso_iec._24727.tech.schema.CardApplicationConnectResponse;
 import iso.std.iso_iec._24727.tech.schema.CardApplicationDisconnect;
@@ -143,12 +144,12 @@ public class PaceCardHelper {
 	return false;
     }
 
-    public EacPinStatus getPinStatus() throws WSHelper.WSException {
+    public PacePinStatus getPinStatus() throws WSHelper.WSException {
 	InputAPDUInfoType input = new InputAPDUInfoType();
 	input.setInputAPDU(new byte[]{(byte) 0x00, (byte) 0x22, (byte) 0xC1, (byte) 0xA4, (byte) 0x0F, (byte) 0x80,
 	    (byte) 0x0A, (byte) 0x04, (byte) 0x00, (byte) 0x7F, (byte) 0x00, (byte) 0x07, (byte) 0x02, (byte) 0x02,
 	    (byte) 0x04, (byte) 0x02, (byte) 0x02, (byte) 0x83, (byte) 0x01, (byte) 0x03});
-	input.getAcceptableStatusCode().addAll(EacPinStatus.getCodes());
+	input.getAcceptableStatusCode().addAll(PacePinStatus.getCodes());
 
 	Transmit transmit = new Transmit();
 	transmit.setSlotHandle(conHandle.getSlotHandle());
@@ -159,7 +160,7 @@ public class PaceCardHelper {
 	byte[] output = pinCheckResponse.getOutputAPDU().get(0);
 	CardResponseAPDU outputApdu = new CardResponseAPDU(output);
 	byte[] status = outputApdu.getStatusBytes();
-	return EacPinStatus.fromCode(status);
+	return PacePinStatus.fromCode(status);
     }
 
     public ConnectionHandleType connectCardIfNeeded() throws WSHelper.WSException, InterruptedException {

--- a/addons/tr03112/src/main/java/org/openecard/sal/protocol/eac/gui/PinState.java
+++ b/addons/tr03112/src/main/java/org/openecard/sal/protocol/eac/gui/PinState.java
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (C) 2019 ecsec GmbH.
+ * Copyright (C) 2019-2020 ecsec GmbH.
  * All rights reserved.
  * Contact: ecsec GmbH (info@ecsec.de)
  *
@@ -10,6 +10,8 @@
 
 package org.openecard.sal.protocol.eac.gui;
 
+import org.openecard.common.ifd.PacePinStatus;
+
 
 /**
  *
@@ -17,67 +19,20 @@ package org.openecard.sal.protocol.eac.gui;
  */
 public class PinState {
 
-    private int attempts;
-    private boolean requestCan;
-    private boolean blocked;
-    private boolean deactivated;
-
-    private EacPinStatus state;
+    private PacePinStatus state;
 
     public PinState() {
-	state = EacPinStatus.RC3;
-	attempts = 2;
-	requestCan = false;
-	blocked = false;
-	deactivated = false;
+	state = PacePinStatus.RC3;
     }
 
-    public void update(EacPinStatus status) {
+    public void update(PacePinStatus status) {
 	if (status == null) {
-	    status = EacPinStatus.UNKNOWN;
+	    status = PacePinStatus.UNKNOWN;
 	}
 	state = status;
-	switch (status) {
-	    case RC3:
-		attempts = 2;
-		requestCan = false;
-		blocked = false;
-		deactivated = false;
-		break;
-	    case RC2:
-		attempts = 1;
-		requestCan = false;
-		blocked = false;
-		deactivated = false;
-		break;
-	    case RC1:
-		attempts = 0;
-		requestCan = true;
-		blocked = false;
-		deactivated = false;
-		break;
-	    case BLOCKED:
-		attempts = 0;
-		requestCan = false;
-		blocked = true;
-		deactivated = false;
-		break;
-	    case DEACTIVATED:
-		attempts = 0;
-		requestCan = false;
-		blocked = false;
-		deactivated = true;
-		break;
-	    case UNKNOWN:
-		attempts = 0;
-		requestCan = false;
-		blocked = false;
-		deactivated = false;
-	}
-
     }
 
-    public EacPinStatus getState() {
+    public PacePinStatus getState() {
 	return state;
     }
 
@@ -95,15 +50,15 @@ public class PinState {
     }
 
     public boolean isRequestCan() {
-	return state == EacPinStatus.RC1;
+	return state == PacePinStatus.RC1;
     }
 
     public boolean isBlocked() {
-	return state == EacPinStatus.BLOCKED;
+	return state == PacePinStatus.BLOCKED;
     }
 
     public boolean isDeactivated() {
-	return state == EacPinStatus.DEACTIVATED;
+	return state == PacePinStatus.DEACTIVATED;
     }
 
     public boolean isOperational() {
@@ -111,7 +66,7 @@ public class PinState {
     }
 
     public boolean isUnknown() {
-	return state == EacPinStatus.UNKNOWN;
+	return state == PacePinStatus.UNKNOWN;
     }
 
 }

--- a/ifd/ifd-protocols/pace/src/main/java/org/openecard/ifd/protocol/pace/PACEProtocol.java
+++ b/ifd/ifd-protocols/pace/src/main/java/org/openecard/ifd/protocol/pace/PACEProtocol.java
@@ -33,7 +33,6 @@ import org.openecard.common.apdu.utils.CardUtils;
 import org.openecard.common.ifd.Protocol;
 import org.openecard.common.ifd.anytype.PACEInputType;
 import org.openecard.common.ifd.anytype.PACEOutputType;
-import org.openecard.common.ifd.protocol.exception.ProtocolException;
 import org.openecard.common.interfaces.Dispatcher;
 import org.openecard.common.tlv.TLV;
 import org.openecard.common.tlv.iso7816.FCP;


### PR DESCRIPTION
This merge request adds the remaining error codes from TR-03130-3, B14.2, so that PIN state of the nPAs yielding these alternative codes are detected properly.
Besides adding the code, it has been refactored a bit, so the PIN status evaluation logic is at least partially shared between IFD, PACE and EAC addon.