### PR TITLE
Register addon manifests for general access

### DIFF
--- a/packager/richclient-bundle/src/main/java/module-info.java
+++ b/packager/richclient-bundle/src/main/java/module-info.java
@@ -76,7 +76,7 @@ module org.openecard.richclient {
     opens generated;
 
     opens org.openecard.mdlw.sal.config to java.xml.bind;
-    opens org.openecard.addon.manifest to java.xml.bind;
+    opens org.openecard.addon.manifest;
 
     opens org.openecard.richclient.gui.update;
 


### PR DESCRIPTION
Due to the design of the plugin management, the addon manifest specification needs to be openly accessible by the plugin modules.